### PR TITLE
EE-33 migrate documentAuthor fields to OID values from DocumentAuthor Lists

### DIFF
--- a/migrations/20190710182340-removeLegacyDocAuthor.js
+++ b/migrations/20190710182340-removeLegacyDocAuthor.js
@@ -1,0 +1,106 @@
+'use strict';
+
+var dbm;
+var type;
+var seed;
+var mongoose = require('mongoose');
+
+/**
+  * We receive the dbmigrate dependency from dbmigrate initially.
+  * This enables us to not have to rely on NODE_PATH.
+  */
+exports.setup = function(options, seedLink) {
+  dbm = options.dbmigrate;
+  type = dbm.dataType;
+  seed = seedLink;
+};
+
+exports.up = function(db) {
+  let mClient;
+  return db.connection.connect(db.connectionString, { native_parser: true})
+    .then((mClientInst) => {
+      mClient = mClientInst;
+      var p = mClient.collection('epic');
+      //get list of new author id's
+      p.aggregate([
+        {
+          $match: { $and: [{ _schemaName: "List" }, { type: "author"} ]}
+        }
+      ])
+        .toArray()
+        .then((authors) => {
+          var author_ids = []
+          var public_id;
+          var eao_id;
+          for (let author of authors) {
+            author_ids.push(String(author._id));
+            if (author.name === 'Public') {
+              public_id = author._id;
+            } else if (author.name === 'EAO') {
+              eao_id = author._id;
+            }
+          }
+          //get documents to update
+          p.aggregate([
+            {
+              $match: { _schemaName: "Document" }
+            }
+          ])
+            .toArray()
+            .then((arr) => {
+              for (let item of arr) {
+                var docAuthor = item.documentAuthor;
+                if (docAuthor) {
+                  if (docAuthor === 'EPIC' || docAuthor === 'EPIC DATA CONVERSION') {
+                    //SET TO EAO ObjectID  ie.  "5cf00c03a266b7e1877504db"
+                    p.update(
+                      {
+                        _id: item._id
+                      },
+                      {
+                        $set: { documentAuthor: eao_id}
+                      }
+                    )
+                  } else if (docAuthor === 'public') {
+                    //SET to PUBLIC ObjectID ie "5cf00c03a266b7e1877504df"
+                    p.update(
+                      {
+                        _id: item._id
+                      },
+                      {
+                        $set: {documentAuthor: public_id}
+                      }
+                    )
+                  } else if (!author_ids.includes(String(docAuthor))) {
+                    //set author to null for any entry with a personal name (id. SallyTest, SALLYTEST, Sally Test)
+                    p.update(
+                      {
+                        _id: item._id
+                      },
+                      {
+                        $set: { documentAuthor: null}
+                      });
+                  }
+                }
+              }
+              mClient.close();
+            })
+              .catch((err) => {
+                console.log("err: ", err);
+                mClient.close();
+            });
+      })
+        .catch((err) => {
+          console.log("err: ", err);
+          mClient.close();
+        });
+    });
+};
+
+exports.down = function(db) {
+  return null;
+};
+
+exports._meta = {
+  "version": 1
+};

--- a/migrations/README.md
+++ b/migrations/README.md
@@ -1,17 +1,42 @@
 ## How to migrate local database
 
-Go into /migrations, and move the changing file OUT of the folder for now, example: 20190411002817-projectDS.js
+### Create migration boilerplate
 
-then run:
+`./node_modules/db-migrate/bin/db-migrate/create myMigrationName`
 
-`./prod-load-db/esm_prod_april_1/dataload.sh && ./node_modules/db-migrate/bin/db-migrate up`
+This will create a date stamped **boilerplate* migration file for you in the `./migrations` directory, such as  *20190625114200-myMigrationName.js* . 
+Modify this file to implement your migration. 
 
-then run:
+### Run a migration
 
-`node migrateDocuments.js`
+` ./node_modules/db-migrate/bin/db-migrate up`
 
-then put 20190411002817-projectDS.js back into the /migrations folder, and re-run:
 
-`./node_modules/db-migrate/bin/db-migrate up`
+### Load dump into db and run migrations (optional)
 
-note that regionCapitalized file is used to capitalize first letter of a region in database.
+
+1. Move your newly generated migration file out of the migrations folder(ie. *20190625114200-myMigrationName.js*). This is to ensure a 
+clean state to test your new migration against.
+
+2. Run the following command to load a dump file and apply all existing migrations:
+
+    1. `cd dumps_folder && mongorestore -d epic some_unzipped_dump/`
+    2. `cd eagle_api_root/ && ./node_modules/db-migrate/bin/db-migrate up`
+    2. `node migrateDocuments.js`
+
+3. Put your new migration file back into the **/migrations** folder and run:
+
+    * `./node_modules/db-migrate/bin/db-migrate up`
+
+### Re-run migration (local testing)
+
+** This won't unclobber data, just allow a rerun of a migration. You may 
+need to dump and restore if the last migration attempt mangled data. **
+
+1. View all migrations applied, in mongo shell
+
+    * `db.migrations.find()`
+
+2. The most recent migration will be at the bottom of the list
+
+    * `db.migrations.deleteOne({ _id: ObjectId(my_most_recent_migrationd_id)})`


### PR DESCRIPTION
EE-33, EE-64

This will fix the core issue behind EE-64.

Currently the documentAuthor values should be the string value of an ObjectID (ie. "5d153b571e8f81ada643bc7a", not ObjectId("5d153b571e8f81ada643bc7a") referencing the DocumentAuthor list in mongo.

This migration removes any old documentAuthor values that are plain names or account names (ie MorganT, Morgan Thomps, MORGAN) by setting them to null.
Additionally this converts values: 
- EPIC and EPIC DATA CONVERSION to the ObjectID for EAO
- public to ObjectID for PUBLIC