### PR TITLE
Connect users and groups

### DIFF
--- a/api/test/factories/audit_factory.js
+++ b/api/test/factories/audit_factory.js
@@ -2,7 +2,9 @@ const factory = require('factory-girl').factory;
 const Audit = require('../../helpers/models/audit');
 let faker = require('faker/locale/en');
 
-factory.define('audit', Audit, buildOptions => {
+const factoryName = Audit.modelName;
+
+factory.define(factoryName, Audit, buildOptions => {
     if (buildOptions.faker) faker = buildOptions.faker;
 
     let attrs = {
@@ -23,3 +25,4 @@ factory.define('audit', Audit, buildOptions => {
 });
 
 exports.factory = factory;
+exports.name = factoryName;

--- a/api/test/factories/comment_factory.js
+++ b/api/test/factories/comment_factory.js
@@ -4,6 +4,8 @@ const factory_helper = require('./factory_helper');
 const moment = require('moment');
 let faker = require('faker/locale/en');
 
+const factoryName = Comment.modelName;
+
 const eaoStatuses = [
   "Deferred"
   , "Published"
@@ -11,7 +13,7 @@ const eaoStatuses = [
   , "Unvetted"
 ];
 
-factory.define('comment', Comment, buildOptions => {
+factory.define(factoryName, Comment, buildOptions => {
   if (buildOptions.faker) faker = buildOptions.faker;
 
   let author = factory_helper.generateFakePerson();
@@ -50,3 +52,4 @@ factory.define('comment', Comment, buildOptions => {
 });
 
 exports.factory = factory;
+exports.name = factoryName;

--- a/api/test/factories/comment_period_factory.js
+++ b/api/test/factories/comment_period_factory.js
@@ -4,6 +4,8 @@ const factory_helper = require('./factory_helper');
 const moment = require('moment');
 let faker = require('faker/locale/en');
 
+const factoryName = CommentPeriod.modelName;
+
 const informationLabels = [
     ""
   , "Amendment #6 Application"
@@ -63,7 +65,7 @@ const vettingRoles = [
   , ["project-team"]
 ];
 
-factory.define('commentPeriod', CommentPeriod, buildOptions => {
+factory.define(factoryName, CommentPeriod, buildOptions => {
   if (buildOptions.faker) faker = buildOptions.faker;
 
   // order dependent chain backwards in time so that the dates make sense
@@ -123,3 +125,4 @@ factory.define('commentPeriod', CommentPeriod, buildOptions => {
 });
 
 exports.factory = factory;
+exports.name = factoryName;

--- a/api/test/factories/document_factory.js
+++ b/api/test/factories/document_factory.js
@@ -4,6 +4,8 @@ const moment = require('moment');
 const Document = require('../../helpers/models/document');
 let faker = require('faker/locale/en');
 
+const factoryName = Document.modelName;
+
 const docProps = [
     { ext: "jpg", mime: "image/jpeg" }
   , { ext: "jpeg", mime: "image/jpeg" }
@@ -20,7 +22,7 @@ const docProps = [
   , { ext: "txt", mime: "text/plain" }
 ];
 
-factory.define('document', Document, buildOptions => {
+factory.define(factoryName, Document, buildOptions => {
   if (buildOptions.faker) faker = buildOptions.faker;
   
   let author = factory_helper.generateFakePerson();
@@ -74,7 +76,7 @@ factory.define('document', Document, buildOptions => {
     , type             : require('mongoose').Types.ObjectId()
     , description      : faker.lorem.sentence()
     , documentAuthor   : author.fullName
-    , documentAuthorType   : require('mongoose').Types.ObjectId()
+    , documentAuthorType   : require('mongoose').Types.ObjectId() // list
     , projectPhase     : require('mongoose').Types.ObjectId()
     , eaoStatus        : faker.random.arrayElement(["", "Published", "Rejected"])
     , keywords         : ""
@@ -87,3 +89,4 @@ factory.define('document', Document, buildOptions => {
 });
 
 exports.factory = factory;
+exports.name = factoryName;

--- a/api/test/factories/factory_helper.js
+++ b/api/test/factories/factory_helper.js
@@ -27,6 +27,10 @@ function generateFakePerson(firstName, middleName, lastName) {
     };
 }
 
+function getRandomExistingUserId(usersPool) {
+    return  (usersPool) ? faker.random.arrayElement(usersPool)._id : require('mongoose').Types.ObjectId();
+}
+
 function loadBcCities() {
     if (0 < bcCities.length) return;
     for (let i = 0; i < canada.cities.length; i++) {
@@ -78,7 +82,9 @@ function generateFakeLocationString() {
     return location;
 }
 
+exports.faker = faker;
 exports.getBcCities = getBcCities;
 exports.generateFakeBcLatLong = generateFakeBcLatLong;
 exports.generateFakePerson = generateFakePerson;
+exports.getRandomExistingUserId = getRandomExistingUserId;
 exports.generateFakeLocationString = generateFakeLocationString;

--- a/api/test/factories/group_factory.js
+++ b/api/test/factories/group_factory.js
@@ -1,14 +1,27 @@
 const factory = require('factory-girl').factory;
+const factory_helper = require('./factory_helper');
 const Group = require('../../helpers/models/group');
 let faker = require('faker/locale/en');
 
-factory.define('group', Group, buildOptions => {
+const factoryName = Group.modelName;
+
+factory.define(factoryName, Group, buildOptions => {
   if (buildOptions.faker) faker = buildOptions.faker;
+  let usersPool = (buildOptions.usersPool) ? buildOptions.usersPool : null;
+
+  const defaultGroupSizeCeiling = 15;
+  let groupSizeCeiling = (usersPool.length < defaultGroupSizeCeiling) ? usersPool.length : defaultGroupSizeCeiling;
+  let groupRandomSize = 1 + faker.random.number(groupSizeCeiling - 1);  // 1-15 not 0-15
+  let members = [];
+  for (i = 0; i < groupRandomSize; i++) {
+    let userId = factory_helper.getRandomExistingUserId(usersPool);
+    if (-1 == members.indexOf(userId)) members.push(userId);
+  }
 
   let attrs = {
       name                    : factory.seq('Group.name', (n) => `Group-${n}`)
     , project                 : require('mongoose').Types.ObjectId()
-    , members                 : [require('mongoose').Types.ObjectId(), require('mongoose').Types.ObjectId(), require('mongoose').Types.ObjectId()]
+    , members                 : members
 
     , read             : faker.random.arrayElement(['["public"]', '["sysadmin"]'])
     , write            : faker.random.arrayElement(['["public"]', '["sysadmin"]'])
@@ -19,3 +32,4 @@ factory.define('group', Group, buildOptions => {
 });
 
 exports.factory = factory;
+exports.name = factoryName;

--- a/api/test/factories/inspection_element_factory.js
+++ b/api/test/factories/inspection_element_factory.js
@@ -3,7 +3,9 @@ const factory_helper = require('./factory_helper');
 const InspectionElement = require('../../helpers/models/inspectionElement');
 let faker = require('faker/locale/en');
 
-factory.define('inspectionElement', InspectionElement, buildOptions => {
+const factoryName = InspectionElement.modelName;
+
+factory.define(factoryName, InspectionElement, buildOptions => {
   if (buildOptions.faker) faker = buildOptions.faker;
   
   let author = factory_helper.generateFakePerson();
@@ -43,3 +45,4 @@ factory.define('inspectionElement', InspectionElement, buildOptions => {
 });
 
 exports.factory = factory;
+exports.name = factoryName;

--- a/api/test/factories/inspection_factory.js
+++ b/api/test/factories/inspection_factory.js
@@ -3,7 +3,9 @@ const factory_helper = require('./factory_helper');
 const Inspection = require('../../helpers/models/inspection');
 let faker = require('faker/locale/en');
 
-factory.define('inspection', Inspection, buildOptions => {
+const factoryName = Inspection.modelName;
+
+factory.define(factoryName, Inspection, buildOptions => {
   if (buildOptions.faker) faker = buildOptions.faker;
   
   let author = factory_helper.generateFakePerson();
@@ -46,3 +48,4 @@ factory.define('inspection', Inspection, buildOptions => {
 });
 
 exports.factory = factory;
+exports.name = factoryName;

--- a/api/test/factories/inspection_item_factory.js
+++ b/api/test/factories/inspection_item_factory.js
@@ -3,13 +3,15 @@ const factory_helper = require('./factory_helper');
 const InspectionItem = require('../../helpers/models/inspectionItem');
 let faker = require('faker/locale/en');
 
+const factoryName = InspectionItem.modelName;
+
 const inspectionItemTypes = [
     "photo"
   , "audio"
   , "video"
 ]
 
-factory.define('inspectionItem', InspectionItem, buildOptions => {
+factory.define(factoryName, InspectionItem, buildOptions => {
   if (buildOptions.faker) faker = buildOptions.faker;
   
   let author = factory_helper.generateFakePerson();
@@ -73,3 +75,4 @@ factory.define('inspectionItem', InspectionItem, buildOptions => {
 });
 
 exports.factory = factory;
+exports.name = factoryName;

--- a/api/test/factories/list_factory.js
+++ b/api/test/factories/list_factory.js
@@ -2,7 +2,9 @@ const factory = require('factory-girl').factory;
 const List = require('../../helpers/models/list');
 let faker = require('faker/locale/en');
 
-factory.define('list', List, buildOptions => {
+const factoryName = List.modelName;
+
+factory.define(factoryName, List, buildOptions => {
   if (buildOptions.faker) faker = buildOptions.faker;
 
   let attrs = {
@@ -12,3 +14,4 @@ factory.define('list', List, buildOptions => {
 });
 
 exports.factory = factory;
+exports.name = factoryName;

--- a/api/test/factories/organization_factory.js
+++ b/api/test/factories/organization_factory.js
@@ -3,6 +3,8 @@ const factory_helper = require('./factory_helper');
 const Organization = require('../../helpers/models/organization');
 let faker = require('faker/locale/en');
 
+const factoryName = Organization.modelName;
+
 const companyTypes = [
   "Consultant"
   , "Indigenous Group"
@@ -14,7 +16,7 @@ const companyTypes = [
   , "Proponent/Certificate Holder"
 ];
 
-factory.define('organization', Organization, buildOptions => {
+factory.define(factoryName, Organization, buildOptions => {
   if (buildOptions.faker) faker = buildOptions.faker;
 
   let author = factory_helper.generateFakePerson();
@@ -51,3 +53,4 @@ factory.define('organization', Organization, buildOptions => {
 });
 
 exports.factory = factory;
+exports.name = factoryName;

--- a/api/test/factories/pin_factory.js
+++ b/api/test/factories/pin_factory.js
@@ -3,7 +3,9 @@ const factory_helper = require('./factory_helper');
 const Pin = require('../../helpers/models/pin');
 let faker = require('faker/locale/en');
 
-factory.define('pin', Pin, buildOptions => {
+const factoryName = Pin.modelName;
+
+factory.define(factoryName, Pin, buildOptions => {
   if (buildOptions.faker) faker = buildOptions.faker;
 
   let pinNum = factory.seq('Pin.number', (n) => `${n}`);
@@ -16,11 +18,12 @@ factory.define('pin', Pin, buildOptions => {
     , province           : "BC"
     , country            : "Canada"
     , postalCode         : chance.postal()
-    , phone              : faker.phone.phoneNumber()
-    , fax                : faker.phone.phoneNumber()
+    , phone              : faker.phone.phoneNumberFormat(1)
+    , fax                : faker.phone.phoneNumberFormat(1)
     , www                : faker.internet.url()
   };
   return attrs;
 });
 
 exports.factory = factory;
+exports.name = factoryName;

--- a/api/test/factories/project_factory.js
+++ b/api/test/factories/project_factory.js
@@ -4,6 +4,8 @@ const factory_helper = require('./factory_helper');
 const Project = require('../../helpers/models/project');
 let faker = require('faker/locale/en');
 
+const factoryName = Project.modelName;
+
 const ceaaInvolvements = [
     "Comp Study"
     , "Comp Study - Unconfirmed"
@@ -133,8 +135,9 @@ const eaStatuses = [
     , "Does not require EAC"
 ];
 
-factory.define('project', Project, buildOptions =>{
+factory.define(factoryName, Project, buildOptions =>{
     if (buildOptions.faker) faker = buildOptions.faker;
+    let usersPool = (buildOptions.usersPool) ? buildOptions.usersPool : null;
 
     let projectName = faker.company.companyName() + " " + faker.random.arrayElement(projectNameSuffixes);
     let decisionDate = moment(faker.date.past(10, new Date()));
@@ -152,7 +155,7 @@ factory.define('project', Project, buildOptions =>{
           CEAAInvolvement         : faker.random.arrayElement(ceaaInvolvements)
         , CELead                  : "Compliance & Enforcement Branch"
         , CELeadEmail             : "eao.compliance@gov.bc.ca"
-        , CELeadPhone             : faker.phone.phoneNumber()
+        , CELeadPhone             : faker.phone.phoneNumberFormat(1)
         , centroid                : factory_helper.generateFakeBcLatLong().centroid
         , description             : faker.lorem.paragraph()
         , eacDecision             : faker.random.arrayElement(eacDecision)
@@ -161,19 +164,19 @@ factory.define('project', Project, buildOptions =>{
         //, projectLeadId           : { type:'ObjectId', default: null }
         , projectLead             : projectLead.fullName
         , projectLeadEmail        : projectLead.emailAddress
-        , projectLeadPhone        : faker.phone.phoneNumber()
+        , projectLeadPhone        : faker.phone.phoneNumberFormat(1)
         //, proponent               : { type:'ObjectId', default: null }
         , region                  : faker.random.arrayElement(regions)
         //, responsibleEPDId        : { type:'ObjectId', default: null }
         , responsibleEPD          : responsibleEpd.fullName
         , responsibleEPDEmail     : responsibleEpd.emailAddress
-        , responsibleEPDPhone     : faker.phone.phoneNumber()
+        , responsibleEPDPhone     : faker.phone.phoneNumberFormat(1)
         , type                    : faker.random.arrayElement(projectTypes)
         , legislation             : ""
 
 
         //Everything else
-        , addedBy                 : require('mongoose').Types.ObjectId()
+        , addedBy                 : factory_helper.getRandomExistingUserId(usersPool)
         , build                   : faker.random.arrayElement(projectBuilds)
         , CEAALink                : "https://www.ceaa-acee.gc.ca/050/evaluations/proj/" + faker.random.number(99999) + "?culture=en-CA"
         , code                    : projectName.replace(/[^A-Z0-9]/ig, "-").replace(/(\-)(\1+)/, "-")
@@ -185,24 +188,18 @@ factory.define('project', Project, buildOptions =>{
         , dateUpdated             : dateUpdated
         , decisionDate            : decisionDate
         , duration                : "90"
-        // TODO: directoryStructure
         , eaoMember               : faker.random.arrayElement(["project-eao-staff", "system-eao"])
-
-        //, epicProjectID           : { type: Number, default: 0 }
         , fedElecDist             : faker.random.arrayElement(federalElectoralDistricts)
-        // TODO: intake
         , intake                  : ""
         , isTermsAgreed           : false
         , overallProgress         : 0
-        , primaryContact          : require('mongoose').Types.ObjectId()
+        , primaryContact          : factory_helper.getRandomExistingUserId(usersPool)
         , proMember               : "proponent-team"
         , provElecDist            : ""
         , sector                  : faker.random.arrayElement(sectors)
         , shortName               : projectName.replace(/[^A-Z0-9]/ig, "-").replace(/(\-)(\1+)/, "-")
         , status                  : faker.random.arrayElement(statuses)
         , substitution            : false
-
-        // TODO: New Stuff?
         , eaStatusDate            : ""
         , eaStatus                : faker.random.arrayElement(eaStatuses)
         , projectStatusDate       : projectStatusDate
@@ -215,26 +212,19 @@ factory.define('project', Project, buildOptions =>{
         // Contact references
         /////////////////////
         // Project Lead
-        , projLead                : require('mongoose').Types.ObjectId()
+        , projLead                : factory_helper.getRandomExistingUserId(usersPool)
 
         // Executive Project Director
-        , execProjectDirector     : require('mongoose').Types.ObjectId()
+        , execProjectDirector     : factory_helper.getRandomExistingUserId(usersPool)
 
         // Compliance & Enforcement Lead
-        , complianceLead          : require('mongoose').Types.ObjectId()
+        , complianceLead          : factory_helper.getRandomExistingUserId(usersPool)
         //////////////////////
 
         /////////////////////
         // PINs
         /////////////////////
         , pins                    : require('mongoose').Types.ObjectId()
-        /*
-        array of mixed:
-        [{
-            action: 'added' | 'removed',
-            date: new Date(now).toISOString()
-        }]
-        */
         , pinsHistory            : {} 
 
         , groups                   : require('mongoose').Types.ObjectId()
@@ -249,3 +239,4 @@ factory.define('project', Project, buildOptions =>{
 });
 
 exports.factory = factory;
+exports.name = factoryName;

--- a/api/test/factories/recent_activity_factory.js
+++ b/api/test/factories/recent_activity_factory.js
@@ -3,8 +3,11 @@ const moment = require('moment');
 const RecentActivity = require('../../helpers/models/recentActivity');
 let faker = require('faker/locale/en');
 
-factory.define('recentActivity', RecentActivity, buildOptions => {
+const factoryName = RecentActivity.modelName;
+
+factory.define(factoryName, RecentActivity, buildOptions => {
   if (buildOptions.faker) faker = buildOptions.faker;
+  let usersPool = (buildOptions.usersPool) ? buildOptions.usersPool : null;
   
   let raType = faker.random.arrayElement(["News", "Public Comment Period"]);
   let dateUpdated = moment(faker.date.past(10, new Date()));
@@ -12,8 +15,8 @@ factory.define('recentActivity', RecentActivity, buildOptions => {
   let attrs = {
       dateUpdated         : dateUpdated
     , dateAdded           : dateAdded
-    , _addedBy            : require('mongoose').Types.ObjectId()
-    , _updatedBy          : require('mongoose').Types.ObjectId()
+    , _addedBy            : factory_helper.getRandomExistingUserId(usersPool)
+    , _updatedBy          : factory_helper.getRandomExistingUserId(usersPool)
     , pinned              : faker.random.boolean()
     , documentUrl         : ("News" == raType) ? "/api/document/" + require('mongoose').Types.ObjectId() + "/fetch": ""
 
@@ -36,3 +39,4 @@ factory.define('recentActivity', RecentActivity, buildOptions => {
 });
 
 exports.factory = factory;
+exports.name = factoryName;

--- a/api/test/factories/user_factory.js
+++ b/api/test/factories/user_factory.js
@@ -3,7 +3,9 @@ const factory_helper = require('./factory_helper');
 const User = require('../../helpers/models/user');
 let faker = require('faker/locale/en');
 
-factory.define('user', User, buildOptions => {
+let factoryName = User.modelName;
+
+factory.define(factoryName, User, buildOptions => {
   if (buildOptions.faker) faker = buildOptions.faker;
 
   let person = factory_helper.generateFakePerson();
@@ -16,11 +18,11 @@ factory.define('user', User, buildOptions => {
     , org                     : require('mongoose').Types.ObjectId()
     , orgName                 : faker.company.companyName()
     , title                   : faker.name.title()
-    , phoneNumber             : faker.phone.phoneNumber()
+    , phoneNumber             : faker.phone.phoneNumberFormat(1)
     , salutation              : faker.name.prefix()
     , department              : faker.name.jobArea()
-    , faxNumber               : faker.phone.phoneNumber()
-    , cellPhoneNumber         : faker.phone.phoneNumber()
+    , faxNumber               : faker.phone.phoneNumberFormat(1)
+    , cellPhoneNumber         : faker.phone.phoneNumberFormat(1)
     , address1                : faker.address.streetAddress()
     , address2                : faker.address.secondaryAddress()
     , city                    : faker.random.arrayElement(factory_helper.getBcCities())
@@ -36,3 +38,4 @@ factory.define('user', User, buildOptions => {
 });
 
 exports.factory = factory;
+exports.name = factoryName;

--- a/api/test/factory_template.js
+++ b/api/test/factory_template.js
@@ -1,0 +1,10 @@
+class FactoryTemplate {
+    constructor(factoryKey, factoryMethod, upperBound, seed) {
+        this.factoryKey = factoryKey;
+        this.factoryMethod = factoryMethod;
+        this.upperBound = upperBound;
+        this.seed = seed;
+    }
+}
+
+module.exports.FactoryTemplate = FactoryTemplate;

--- a/api/test/generate.test.js
+++ b/api/test/generate.test.js
@@ -24,7 +24,7 @@ describe('Generate Test Data', () => {
         // Default is to not run the data generator when running global tests
         if (genSettings.generate) {
           console.log("Data Generation is on");
-          gh.generateAll(usersData).then(generatedData =>{
+          gh.generateEntireDatabase(usersData).then(generatedData =>{
             console.log(((genSettings.generate_consistent_data) ? "Consistent" : "Random") + " data generation " + ((genSettings.save_to_persistent_mongo) ? "saved" : "unsaved"));
             //console.log('generatedData: [' + generatedData + ']');
             let projects = generatedData.projects;

--- a/api/test/generate_helper.js
+++ b/api/test/generate_helper.js
@@ -8,68 +8,96 @@ const mongoose = require('mongoose');
 mongoose.Promise = require('bluebird'); // for extra debugging capabilities
 //mongoose.Promise = global.Promise;  // without debugging extras
 require('../helpers/models/audit');
-const auditFactory = require("./factories/audit_factory").factory;
-const userFactory = require("./factories/user_factory").factory;
-const projectFactory = require("./factories/project_factory").factory;
-const commentPeriodFactory = require("./factories/comment_period_factory").factory;
-const commentFactory = require("./factories/comment_factory").factory;
-const documentFactory = require("./factories/document_factory").factory;
+const factory = require('factory-girl').factory;
+//the following include statements populate the 'factories' collection of factory-girl's singleton factory object
+const auditFactory = require("./factories/audit_factory");
+const userFactory = require("./factories/user_factory");
+const projectFactory = require("./factories/project_factory");
+const commentPeriodFactory = require("./factories/comment_period_factory");
+const commentFactory = require("./factories/comment_factory");
+const documentFactory = require("./factories/document_factory");
+const groupFactory = require("./factories/group_factory");
 require('../helpers/models/user');
 require('../helpers/models/project');
+let ft = require('./factory_template');
 let gd = require('./generated_data');
 
-// Generate [0] to [CeilingValue] of the following objects
+// Used to generate random values in the range [0 to CeilingValue] for correspondingly named objects
 let generatorCeilings = {
-  documentsPerProject: 20
-, commentPeriodsPerProject: 2
-, documentsPerCommentPeriod: 3
-, commentsPerCommentPeriod: 300
+    extraUsers: 50
+  , documentsPerProject: 20
+  , commentPeriodsPerProject: 2
+  , documentsPerCommentPeriod: 3
+  , commentsPerCommentPeriod: 300
+  , groupsPerProject: 4
 };
-let gc = generatorCeilings; // shorthand alias for brevity
+let gc = generatorCeilings;
 
 const uniqueStaticSeeds = {
     audit: 1
-  , user: 234
+  , guaranteedUser: 234
+  , extraUser: 106
   , project: 345
   , projectDocument: 105
   , commentPeriod: 101
   , commentPeriodDocument: 104
   , comment: 102
+  , group: 924
 };
-const uss = uniqueStaticSeeds; // shorthand alias for brevity
+const uss = uniqueStaticSeeds;
+
+const commentPeriodTemplate = new ft.FactoryTemplate(commentPeriodFactory.name, generateCommentPeriodSetForProject, gc.commentPeriodsPerProject, uss.commentPeriod);
+const commentTemplate = new ft.FactoryTemplate(commentFactory.name, generateCommentSetForCommentPeriod, gc.commentsPerCommentPeriod, uss.comment);
+const projectDocumentTemplate = new ft.FactoryTemplate(documentFactory.name, generateDocumentSetForProject, gc.documentsPerProject, uss.projectDocument);
+const commentPeriodDocumentTemplate = new ft.FactoryTemplate(documentFactory.name, generateDocumentSetForCommentPeriod, gc.documentsPerCommentPeriod, uss.commentPeriodDocument);
+const groupTemplate = new ft.FactoryTemplate(groupFactory.name, generateGroupSetForProject, gc.groupsPerProject, uss.group);
 
 // Data generation violates the single purpose principle on purpose.
 // It generates data, saves model to db (mem or real), and outputs the data we generated
 // so we can check that it got saved properly later and manipulate the data for tests.
 // We do this because we are no longer using static seeded data.
-function generateAll(usersData) {
+function generateEntireDatabase(usersData) {
+  // generate an Audit object needed by the app models, a mix of constant (test entry points) and random Users, and a number of Projects
   return generateProjects(usersData)
   .then(generatedData => { 
+    // foreach Project, generate the Groups relating to it
     return new Promise(function(resolve, reject) {
-      generateCommentPeriods(generatedData.projects).then(commentPeriods => {
+      generateChildSets(generatedData.projects, generatedData.users, groupTemplate).then(groups => {
+        generatedData.groups = groups;
+        resolve(generatedData);
+      });
+    });
+  })
+  .then(generatedData => { 
+    // foreach Project, generate the Comment Periods relating to it
+    return new Promise(function(resolve, reject) {
+      generateChildSets(generatedData.projects, generatedData.users, commentPeriodTemplate).then(commentPeriods => {
         generatedData.commentPeriods = commentPeriods;
         resolve(generatedData);
       });
     });
   })
   .then(generatedData => { 
+    // foreach Comment Period, generate the Comments relating to it
     return new Promise(function(resolve, reject) {
-      generateComments(generatedData.commentPeriods).then(comments => {
+      generateChildSets(generatedData.commentPeriods, generatedData.users, commentTemplate).then(comments => {
         generatedData.comments = comments;
         resolve(generatedData);
       });
     });
   })
   .then(generatedData => { 
+    // foreach Comment Period, generate the Documents relating to it
     return new Promise(function(resolve, reject) {
-      generateDocumentsForCommentPeriods(generatedData.commentPeriods).then(commentPeriodDocuments => {
+      generateChildSets(generatedData.commentPeriods, generatedData.users, commentPeriodDocumentTemplate).then(commentPeriodDocuments => {
         generatedData.commentPeriodDocuments = commentPeriodDocuments;
         resolve(generatedData);
       });
     });
   }).then(generatedData => { 
+    // foreach Project, generate the Documents relating to it
     return new Promise(function(resolve, reject) {
-      generateDocumentsForProjects(generatedData.projects).then(projectDocuments => {
+      generateChildSets(generatedData.projects, generatedData.users, projectDocumentTemplate).then(projectDocuments => {
         generatedData.projectDocuments = projectDocuments;
         resolve(generatedData);
       });
@@ -77,146 +105,53 @@ function generateAll(usersData) {
   });
 };
 
-
-function generateCommentPeriods(projects) {
+function generateGroupSetForProject(factoryKey, project, buildOptions, groupsToGen) {
   return new Promise(function(resolve, reject) {
-    let commentPeriodPromises = projects.map(project => {
-      return generateCommentPeriod(project);
-    });
-    resolve(Promise.all(commentPeriodPromises));
-  }).catch(error => {
-    console.log("Comment periods error:" + error);
-    reject(error);
-  }).finally(function(){
-    console.log('Generated comment periods.');
-  });
-};
-
-function generateCommentPeriod(project) {
-    return new Promise(function(resolve, reject) {
-      test_helper.dataGenerationSettings.then(genSettings => {
-        (genSettings.generate_consistent_data) ? faker.seed(uss.commentPeriod) : faker.seed();
-        let commentPeriodsToGen = faker.random.number(gc.commentPeriodsPerProject).valueOf();
-        if (0 < commentPeriodsToGen) {
-          commentPeriodFactory.createMany('commentPeriod', commentPeriodsToGen, { project: project._id }).then(commentPeriodsArray => {
-            resolve(commentPeriodsArray);
-          });
-        } else {
-          resolve([]);
-        }
-      });
-    }).catch(error => {
-      console.log("Comment period error:" + error);
-      reject(error);
-    }).finally(function(){
-      console.log('Generated comment period.');
-    });
-};
-
-function generateComments(commentPeriods) {
-  return new Promise(function(resolve, reject) {
-    let commentPromises = commentPeriods.map((commentPeriod) => {
-      return generateComment(commentPeriod);
-    });
-    resolve(Promise.all(commentPromises));
-  }).catch(error => {
-    console.log("Comments error:" + error);
-    reject(error);
-  }).finally(function(){
-    console.log('Generated comments.');
-  });
-};
-
-function generateComment(commentPeriod) {
-  return new Promise(function(resolve, reject) {
-    test_helper.dataGenerationSettings.then(genSettings => {
-      (genSettings.generate_consistent_data) ? faker.seed(uss.comment) : faker.seed();
-      let commentsToGen = faker.random.number(gc.commentsPerCommentPeriod).valueOf();
-      if (0 < commentsToGen) {
-        commentFactory.createMany('comment', commentsToGen, { commentPeriod: commentPeriod._id }).then(commentsArray => {
-          resolve(commentsArray);
-        });
-      } else {
-        resolve([]);
+    let customGroupSettings = { project: project._id };
+    factory.createMany(factoryKey, groupsToGen, customGroupSettings, buildOptions).then(groups => {
+      let groupIds = [];
+      for (i = 0; i < groups.length; i++) {
+        if (-1 == groupIds.indexOf(groups[i].id)) groupIds.push(groups[i].id); 
       }
+      project.groups = groupIds;
+      resolve(groups);
     });
-  }).catch(error => {
-    console.log("Comment error:" + error);
-    reject(error);
-  }).finally(function(){
-    console.log('Generated comment.');
   });
 };
 
-function generateDocumentsForProjects(projects) {
+function generateCommentPeriodSetForProject(factoryKey, project, buildOptions, commentPeriodsToGen) {
   return new Promise(function(resolve, reject) {
-    let projectDocumentPromises = projects.map((project) => {
-      return generateDocumentForProject(project);
+    let customCommentPeriodSettings = { project: project._id };
+    factory.createMany(factoryKey, commentPeriodsToGen, customCommentPeriodSettings, buildOptions).then(commentPeriods => {
+      resolve(commentPeriods);
     });
-    resolve(Promise.all(projectDocumentPromises));
-  }).catch(error => {
-    console.log("Projects documents error:" + error);
-    reject(error);
-  }).finally(function(){
-    console.log('Generated projects documents.');
   });
 };
 
-function generateDocumentForProject(project) {
+function generateCommentSetForCommentPeriod(factoryKey, commentPeriod, buildOptions, commentsToGen) {
   return new Promise(function(resolve, reject) {
-    test_helper.dataGenerationSettings.then(genSettings => {
-      (genSettings.generate_consistent_data) ? faker.seed(uss.projectDocument) : faker.seed();
-      let projectDocumentsToGen = faker.random.number(gc.documentsPerProject).valueOf();
-      let customDocumentSettings = { documentSource: "PROJECT", project: project._id };
-      if (0 < projectDocumentsToGen) {
-        documentFactory.createMany('document', projectDocumentsToGen, customDocumentSettings).then(documentsArray => {
-          resolve(documentsArray);
-        });
-      } else {
-        resolve([]);
-      }
+    let customCommentSettings = { commentPeriod: commentPeriod._id };
+    factory.createMany(factoryKey, commentsToGen, customCommentSettings, buildOptions).then(comments => {
+      resolve(comments);
     });
-  }).catch(error => {
-    console.log("Project document error:" + error);
-    reject(error);
-  }).finally(function(){
-    console.log('Generated project document.');
   });
 };
 
-function generateDocumentsForCommentPeriods(commentPeriods) {
+function generateDocumentSetForProject(factoryKey, project, buildOptions, projectDocumentsToGen) {
   return new Promise(function(resolve, reject) {
-    let commentPeriodDocumentPromises = commentPeriods.map((commentPeriod) => {
-      return generateDocumentForCommentPeriod(commentPeriod);
+    let customDocumentSettings = { documentSource: "PROJECT", project: project._id };
+    factory.createMany(factoryKey, projectDocumentsToGen, customDocumentSettings, buildOptions).then(documents => {
+      resolve(documents);
     });
-    resolve(Promise.all(commentPeriodDocumentPromises));
-  }).catch(error => {
-    console.log("Comment periods documents error:" + error);
-    reject(error);
-  }).finally(function(){
-    console.log('Generated comment periods documents.');
   });
 };
 
-function generateDocumentForCommentPeriod(commentPeriod) {
+function generateDocumentSetForCommentPeriod(factoryKey, commentPeriod, buildOptions, commentPeriodDocumentsToGen) {
   return new Promise(function(resolve, reject) {
-    test_helper.dataGenerationSettings.then(genSettings => {
-      (genSettings.generate_consistent_data) ? faker.seed(uss.commentPeriodDocument) : faker.seed();
-      let commentPeriodDocumentsToGen = faker.random.number(gc.documentsPerCommentPeriod).valueOf();
-      let customDocumentSettings = { documentSource: "COMMENT", project: commentPeriod.project, _comment: commentPeriod._id };
-      if (0 < commentPeriodDocumentsToGen) {
-        documentFactory.createMany('document', commentPeriodDocumentsToGen, customDocumentSettings).then(documentsArray => {
-          resolve(documentsArray);
-        });
-      } else {
-        resolve([]);
-      }
+  let customDocumentSettings = { documentSource: "COMMENT", project: commentPeriod.project, _comment: commentPeriod._id };
+    factory.createMany(factoryKey, commentPeriodDocumentsToGen, customDocumentSettings, buildOptions).then(documents => {
+      resolve(documents);
     });
-  }).catch(error => {
-    console.log("Comment period document error:" + error);
-    reject(error);
-  }).finally(function(){
-    console.log('Generated comment period document.');
   });
 };
 
@@ -227,20 +162,24 @@ function generateProjects(usersData) {
       let numOfProjsGenned = 0;
       if (isNaN(numOfProjsToGen)) numOfProjsToGen = test_helper.defaultNumberOfProjects;
       console.log('Generating ' + numOfProjsToGen + ' projects.');
-      auditFactory.create('audit', {}, {faker: getSeeded(genSettings.generate_consistent_data, uss.audit)}).then(audit =>{
-        userFactory.createMany('user', usersData, {faker: getSeeded(genSettings.generate_consistent_data, uss.user)}).then(usersArray => {
-          projectFactory.createMany('project', numOfProjsToGen, {}, {faker: getSeeded(genSettings.generate_consistent_data, uss.project)}).then(projectsArray => {
-            numOfProjsGenned = projectsArray.length;
-            let genData = new gd.GeneratedData();
-            genData.audit = audit;
-            genData.users = usersArray;
-            genData.projects = projectsArray;
-            resolve(genData);
-          }).catch(error => {
-            console.log("Project error:" + error);
-            reject(error);
-          }).finally(function(){
-            console.log('Generated ' + numOfProjsGenned + ' projects.');
+      
+      factory.create(auditFactory.name, {}, {faker: getSeeded(genSettings.generate_consistent_data, uss.audit)}).then(audit =>{
+        factory.createMany(userFactory.name, usersData, {faker: getSeeded(genSettings.generate_consistent_data, uss.guaranteedUser)}).then(guaranteedUsersArray => {
+          factory.createMany(userFactory.name, generatorCeilings.extraUsers, {}, {faker: getSeeded(genSettings.generate_consistent_data, uss.extraUser)}).then(extraUsersArray => {
+            let users = guaranteedUsersArray.concat(extraUsersArray);            
+            factory.createMany(projectFactory.name, numOfProjsToGen, {}, {faker: getSeeded(genSettings.generate_consistent_data, uss.project), usersPool: users}).then(projectsArray => {
+              numOfProjsGenned = projectsArray.length;
+              let genData = new gd.GeneratedData();
+              genData.audit = audit;
+              genData.users = users;
+              genData.projects = projectsArray;
+              resolve(genData);
+            }).catch(error => {
+              console.log("Project error:" + error);
+              reject(error);
+            }).finally(function(){
+              console.log('Generated ' + numOfProjsGenned + ' projects.');
+            });
           });
         });
       });
@@ -249,14 +188,47 @@ function generateProjects(usersData) {
   return projectGenerator;
 };
 
+function generateChildSets(parents, usersPool, factoryTemplate) {
+  if (0 == parents.length) return new Promise(function(resolve, reject) { resolve([]); });
+  return new Promise(function(resolve, reject) {
+    test_helper.dataGenerationSettings.then(genSettings => {
+      let buildOptions = {faker: getSeeded(genSettings.generate_consistent_data, factoryTemplate.seed), usersPool: usersPool}
+      let childGenerationPromises = parents.map(parent => {
+        return generateChildSet(parent, buildOptions, factoryTemplate);
+      });
+      resolve(Promise.all(childGenerationPromises));
+    });
+  }).catch(error => {
+    console.log(factoryTemplate.factoryKey + "s error:" + error);
+    reject(error);
+  }).finally(function(){
+    console.log("Generated all " + factoryTemplate.factoryKey + " sets.");
+  });
+}
+
+function generateChildSet(parent, buildOptions, factoryTemplate) {
+  return new Promise(function(resolve, reject) {
+    test_helper.dataGenerationSettings.then(genSettings => {
+      (genSettings.generate_consistent_data) ? faker.seed(factoryTemplate.seed) : faker.seed();
+      let childrenToGen = faker.random.number(factoryTemplate.upperBound).valueOf();
+      if (0 < childrenToGen) {
+        resolve(factoryTemplate.factoryMethod(factoryTemplate.factoryKey, parent, buildOptions, childrenToGen));
+      } else {
+        resolve([]);
+      }
+    });
+  }).catch(error => {
+    console.log(factoryTemplate.factoryKey + " set generation error:" + error);
+    reject(error);
+  }).finally(function(){
+    console.log("Generated " + factoryTemplate.factoryKey + " set.");
+  });
+};
+
 function getSeeded(setConstant, seed) {
   return (setConstant) ? (require('faker/locale/en')).seed(seed) : (require('faker/locale/en')).seed();
 }
 
 exports.uss = uniqueStaticSeeds; // external shorthand alias for brevity
-exports.generateAll = generateAll;
-exports.generateCommentPeriods = generateCommentPeriods;
-exports.generateCommentPeriod = generateCommentPeriod;
-exports.generateComments = generateComments;
-exports.generateComment = generateComment;
-exports.generateProjects = generateProjects;
+exports.generateEntireDatabase = generateEntireDatabase;
+;

--- a/api/test/generate_helper.js
+++ b/api/test/generate_helper.js
@@ -148,7 +148,7 @@ function generateDocumentSetForProject(factoryKey, project, buildOptions, projec
 
 function generateDocumentSetForCommentPeriod(factoryKey, commentPeriod, buildOptions, commentPeriodDocumentsToGen) {
   return new Promise(function(resolve, reject) {
-  let customDocumentSettings = { documentSource: "COMMENT", project: commentPeriod.project, _comment: commentPeriod._id };
+  let customDocumentSettings = { documentSource: "COMMENT", project: commentPeriod.project, _comment: commentPeriod._id };  // note that the document._comment field actually refers to a commentPeriod id
     factory.createMany(factoryKey, commentPeriodDocumentsToGen, customDocumentSettings, buildOptions).then(documents => {
       resolve(documents);
     });

--- a/api/test/generated_data.js
+++ b/api/test/generated_data.js
@@ -7,6 +7,7 @@ class GeneratedData {
         this.commentPeriods = null;
         this.commentPeriodComments = null;
         this.commentPeriodDocuments = null;
+        this.groups = null;
     }
 }
 

--- a/api/test/model_change_watcher_hash.json
+++ b/api/test/model_change_watcher_hash.json
@@ -68,59 +68,59 @@
   "factories": [
     {
       "name": "audit_factory.js",
-      "hash": "0ETEQLsBpgNc9zRnTSsqxfrw69g="
+      "hash": "m6gNaAGY6ZLJR44HyePzZrz7a7A="
     },
     {
       "name": "comment_factory.js",
-      "hash": "4Lj9FAbKQLeGx4Jy7Fdu6EdQ+2E="
+      "hash": "gqbC8a0JTukk6Et17fqWxytAN/Q="
     },
     {
       "name": "comment_period_factory.js",
-      "hash": "j2e+sesVDwCBQZKScBPA/060gcE="
+      "hash": "sxyD6R1p/QPhX/SQxFcqJxd1pd0="
     },
     {
       "name": "document_factory.js",
-      "hash": "hD4wbGKgsVxUylCtlJavxeU125w="
+      "hash": "a+fYvLeyCtBtsNuZI/0G7xwW/UQ="
     },
     {
       "name": "group_factory.js",
-      "hash": "t/uWw/p/NyOJDgEoPja7PmwILC8="
+      "hash": "MwieOpsV3oTrPcQ0SeB+MI3M0TY="
     },
     {
       "name": "inspection_element_factory.js",
-      "hash": "4qEvBy/b5XBGsygHpXisl44lVek="
+      "hash": "8EdPc/GuwH0B4wZ5gwc/8MyMYPQ="
     },
     {
       "name": "inspection_factory.js",
-      "hash": "PT4sOfMhokemFbrxZHyVhGNdUYk="
+      "hash": "HLB/pHT6mIUbMcpXWwceunUKxrY="
     },
     {
       "name": "inspection_item_factory.js",
-      "hash": "lT1iwTEye/1zvK+xbWgUDCnFmpY="
+      "hash": "bey/TVMjMLTevkSkhkM/8gN8fCU="
     },
     {
       "name": "list_factory.js",
-      "hash": "yHu1zbgtSH9n2VIZ28NWGdvY4Ns="
+      "hash": "NV9M3/gKaX3rf4mziyCpR0JLUY0="
     },
     {
       "name": "organization_factory.js",
-      "hash": "PqG2lGJXCUAMTPYt7IMuzESCA8k="
+      "hash": "Trqb/rsHo6U61GdCRB5my/7IPOI="
     },
     {
       "name": "pin_factory.js",
-      "hash": "vGNFpZa937SHAFFrExcVk5d1qgg="
+      "hash": "+NnMvhHGZAZx4QRGGoT9A597wwk="
     },
     {
       "name": "project_factory.js",
-      "hash": "vwwVTJ7Coway/o8BCLrslT7HUU8="
+      "hash": "JUQdU5VrrMKbnNFCFuxrWFbM2Tk="
     },
     {
       "name": "recent_activity_factory.js",
-      "hash": "5Ygx1gEIr8MKNsXyVsOo49Q0A5M="
+      "hash": "Xvgc+wt3wHRoIEvIMXN0onuXHhI="
     },
     {
       "name": "user_factory.js",
-      "hash": "A8g3HBnGH9TnaBCAS/sCm+DAkxM="
+      "hash": "2bjmdMBhWqd9+mxjwq3yAiPK/q4="
     }
   ]
 }


### PR DESCRIPTION
Users and groups are now connected throughout the generated data.

Refactored out the commonalities from the generation methods into generic methods, now passing settings in instead.

Set phone number format to BC norms eg. (987) 654-3210

Tested in bash (Jenkins is using bash not zsh) with the following 3 commands from the project root:
npm run tests
./generate.sh 2
./generate.sh 2 Random Unsaved

...where npm run tests is what is being performed in our pipeline, and generate.sh is how one could do either a 1 time data generation or use as a base case for having mock in-memory data for unit testing.  Visual [here](https://github.com/bcgov/eagle-dev-guides/blob/master/dev_guides/images/epic_data_generation.png).

Pls note that api/test/generate_helper.js is where most of the work occurred and is by default minimized by GitHub diff.  Expand it to review.