### PR TITLE
EE-433 Update EA Decision and CEAA Lists

### DIFF
--- a/api/controllers/search.js
+++ b/api/controllers/search.js
@@ -789,6 +789,8 @@ var searchCollection = async function (roles, keywords, schemaName, pageNum, pag
       ]
     }
   });
+console.log(JSON.stringify(aggregation));
+
   return new Promise(function (resolve, reject) {
     var collectionObj = mongoose.model(schemaName);
     collectionObj.aggregate(aggregation)

--- a/api/controllers/search.js
+++ b/api/controllers/search.js
@@ -287,7 +287,7 @@ var unwindProjectData = function (aggregation, projectLegislationDataKey, projec
           [projectLegislationDataKey + ".read"]: "$read",
           [projectLegislationDataKey + ".pins"]: "$pins",
           [projectLegislationDataKey + ".pinsHistory"]: "$pinsHistory",
-          [projectLegislationDataKey + ".pinsRead"]: "$pinsRead",
+          [projectLegislationDataKey + ".pinsRead"]: "$pinsRead"
         }
       }
     );
@@ -304,7 +304,7 @@ var unwindProjectData = function (aggregation, projectLegislationDataKey, projec
           [projectLegislationDataIdKey]: '$_id',
           [projectLegislationDataKey + ".read"]: "$read",
           [projectLegislationDataKey + ".pins"]: "$pins",
-          [projectLegislationDataKey + ".pinsHistory"]: "$pinsHistory",
+          [projectLegislationDataKey + ".pinsHistory"]: "$pinsHistory"
         }
       }
     );
@@ -789,7 +789,6 @@ var searchCollection = async function (roles, keywords, schemaName, pageNum, pag
       ]
     }
   });
-console.log(JSON.stringify(aggregation));
 
   return new Promise(function (resolve, reject) {
     var collectionObj = mongoose.model(schemaName);

--- a/api/helpers/models/project.js
+++ b/api/helpers/models/project.js
@@ -6,13 +6,13 @@ var Mixed = mongoose.Schema.Types.Mixed;
 var projectDataDefinition = {
 
   //Needed for default view
-  CEAAInvolvement         : { type: String, default: '' },
+  CEAAInvolvement         : { type:'ObjectId', default: null },
   CELead                  : { type: String, default: '' },
   CELeadEmail             : { type: String, default: '' },
   CELeadPhone             : { type: String, default: '' },
   centroid                : [{ type: Mixed, default: 0.00}],
   description             : { type: String, default: '' },
-  eacDecision             : { type: String, default: '' },
+  eacDecision             : { type:'ObjectId', default: null },
   location                : { type: String, default: '' },
   name                    : { type: String, trim: true },
   projectLeadId           : { type:'ObjectId', default: null },

--- a/migrations/20200106657647-addProjectListTypes.js
+++ b/migrations/20200106657647-addProjectListTypes.js
@@ -1,0 +1,56 @@
+'use strict';
+
+let dbm;
+let type;
+let seed;
+
+/**
+  * We receive the dbmigrate dependency from dbmigrate initially.
+  * This enables us to not have to rely on NODE_PATH.
+  */
+exports.setup = function(options, seedLink) {
+  dbm = options.dbmigrate;
+  type = dbm.dataType;
+  seed = seedLink;
+};
+
+const listItems = require(process.cwd() + '/migrations_data/eaDecisionsAndIAACInvolvment');
+
+exports.up = function(db) {
+  let mClient;
+  return db.connection.connect(db.connectionString, { native_parser: true })
+    .then((mClient) => {
+      const collection = mClient.collection('epic');
+console.log(listItems);
+      // Insert new list items
+      collection.insertMany(
+        listItems
+        )
+        .then(function (arr) {
+          console.log("arr:", arr)
+          for(let item of arr.ops) {
+            collection.update(
+            {
+              _id: item._id
+            },
+            {
+              $set: { read: ['public', 'staff', 'sysadmin'], write: ['staff', 'sysadmin'] }
+            });
+          }
+          mClient.close();
+      });
+    })
+    .catch((e) => {
+      console.log("e:", e);
+      mClient.close()
+    });
+};
+  
+
+exports.down = function(db) {
+  return null;
+};
+
+exports._meta = {
+  "version": 1
+};

--- a/migrations/20200106657647-addProjectListTypes.js
+++ b/migrations/20200106657647-addProjectListTypes.js
@@ -19,9 +19,10 @@ const listItems = require(process.cwd() + '/migrations_data/eaDecisionsAndIAACIn
 exports.up = function(db) {
   let mClient;
   return db.connection.connect(db.connectionString, { native_parser: true })
-    .then((mClient) => {
+    .then((client) => {
+      mClient = client;
+      
       const collection = mClient.collection('epic');
-console.log(listItems);
       // Insert new list items
       collection.insertMany(
         listItems

--- a/migrations/20200106938494-updateEaoIaacKeys.js
+++ b/migrations/20200106938494-updateEaoIaacKeys.js
@@ -1,0 +1,170 @@
+'use strict';
+
+const mongoose = require('mongoose');
+
+let dbm;
+let type;
+let seed;
+
+/**
+  * We receive the dbmigrate dependency from dbmigrate initially.
+  * This enables us to not have to rely on NODE_PATH.
+  */
+exports.setup = function(options, seedLink) {
+  dbm = options.dbmigrate;
+  type = dbm.dataType;
+  seed = seedLink;
+};
+
+exports.up = function(db) {
+  let mClient;
+  const errors = [];
+
+  return db.connection.connect(db.connectionString, { native_parser: true })
+    .then(async (client) => {
+      const updatePromises = [];
+      mClient = client;
+      
+      const collection = mClient.collection('epic');
+
+      // Get the EA Decisions.
+      const eaDecisions = await collection.aggregate([
+        { $match: { _schemaName:'List', type: 'eaDecisions' } }
+      ])
+      .toArray();
+
+      // Get IAAC Involvements.
+      const iaacInvolements = await collection.aggregate([
+        { $match: { _schemaName: 'List', type: 'ceaaInvolvements' } }
+      ])
+      .toArray();
+
+      // Get all projects.
+      const projects = await collection.aggregate([
+        { $match: { _schemaName:'Project' } }
+      ])
+      .toArray();
+
+      projects.forEach(project => {
+        if (project.legislation_1996) {
+          // Use the 2002 terms for 1996.
+          const ceaaInvolvementId = getNameId(project.legislation_1996.CEAAInvolvement,  2002, iaacInvolements);
+          const eaDecisionId = getNameId(project.legislation_1996.eacDecision, 2002, eaDecisions);
+
+          if (ceaaInvolvementId && eaDecisionId) {
+            updatePromises.push(
+              collection.update(
+                {
+                  _id: project._id
+                },
+                {
+                  $set: {
+                    'legislation_1996.CEAAInvolvement': mongoose.Types.ObjectId(ceaaInvolvementId),
+                    'legislation_1996.eacDecision':mongoose.Types.ObjectId(eaDecisionId)
+                  }
+                }
+              )
+            );
+          } 
+          else {
+            errors.push({
+              projectId: project._id, 
+              message: `CEAAInvolvement: '${project.legislation_1996.CEAAInvolvement}' found '${ceaaInvolvementId}',
+                        eacDecision: '${project.legislation_1996.eacDecision}' found '${eaDecisionId}'`
+            });
+          }
+          
+        }
+
+        if (project.legislation_2002) {
+          const ceaaInvolvementId = getNameId(project.legislation_2002.CEAAInvolvement, 2002, iaacInvolements);
+          const eaDecisionId = getNameId(project.legislation_2002.eacDecision, 2002, eaDecisions);
+
+          if (ceaaInvolvementId && eaDecisionId) {
+            updatePromises.push(
+              collection.update(
+                {
+                  _id: project._id
+                },
+                {
+                  $set: {
+                    'legislation_2002.CEAAInvolvement': mongoose.Types.ObjectId(ceaaInvolvementId),
+                    'legislation_2002.eacDecision': mongoose.Types.ObjectId(eaDecisionId)
+                  }
+                }
+              )
+            );
+          } 
+          else {
+            errors.push({
+              projectId: project._id, 
+              message: `CEAAInvolvement: '${project.legislation_2002.CEAAInvolvement}' found '${ceaaInvolvementId}',
+                        eacDecision: '${project.legislation_2002.eacDecision}' found '${eaDecisionId}'`
+            });
+          }
+        }
+
+        if (project.legislation_2018) {
+          const ceaaInvolvementId = getNameId(project.legislation_2018.CEAAInvolvement, 2018, iaacInvolements);
+          const eaDecisionId = getNameId(project.legislation_2018.eacDecision, 2018, eaDecisions);
+
+          if (ceaaInvolvementId && eaDecisionId) {
+            updatePromises.push(
+              collection.update(
+                {
+                  _id: project._id
+                },
+                {
+                  $set: {
+                    'legislation_2018.CEAAInvolvement': mongoose.Types.ObjectId(ceaaInvolvementId),
+                    'legislation_2018.eacDecision': mongoose.Types.ObjectId(eaDecisionId)
+                  }
+                }
+              )
+            );
+          }
+          else {
+            errors.push({
+              projectId: project._id, 
+              message: `CEAAInvolvement: '${project.legislation_2018.CEAAInvolvement}' found '${ceaaInvolvementId}',
+                        eacDecision: '${project.legislation_2018.eacDecision}' found '${eaDecisionId}'`
+            });
+          }
+        }
+      });
+
+      // Wait for all promises to resolve before closing the DB connection.
+      await Promise.all(updatePromises);
+
+      // Print any errors.
+      if (errors.length > 0) {
+        console.log('Errors updating project keys: ', JSON.stringify(errors));
+      }
+
+      mClient.close();
+    })
+    .catch((e) => {
+      console.log('e:', e);
+      mClient.close();
+    });
+};
+  
+
+exports.down = function(db) {
+  return null;
+};
+
+exports._meta = {
+  'version': 1
+};
+
+
+const getNameId = (name, year, collection) => {
+  const matchedItem = collection.find(item => (item.name === name && item.legislation === year));
+  if (matchedItem && matchedItem._id) {
+    return matchedItem._id;
+  }
+  else {
+    return undefined;
+  }
+};

--- a/migrations_data/eaDecisionsAndIAACInvolvment.js
+++ b/migrations_data/eaDecisionsAndIAACInvolvment.js
@@ -1,0 +1,298 @@
+module.exports = [  
+  ///// CEAA Involvements /////
+  {
+    _schemaName: "List",
+    type: "ceaaInvolvements",
+    legislation: 2002,
+    name: "None",
+    listOrder: 0
+  },
+  {
+    _schemaName: "List",
+    type: "ceaaInvolvements",
+    legislation: 2002,
+    name: "Panel",
+    listOrder: 10
+  },
+  {
+    _schemaName: "List",
+    type: "ceaaInvolvements",
+    legislation: 2002,
+    name: "Panel (CEAA 2012)",
+    listOrder: 20
+  },
+  {
+    _schemaName: "List",
+    type: "ceaaInvolvements",
+    legislation: 2002,
+    name: "Coordinated",
+    listOrder: 30
+  },
+  {
+    _schemaName: "List",
+    type: "ceaaInvolvements",
+    legislation: 2002,
+    name: "Screening",
+    listOrder: 40
+  },
+  {
+    _schemaName: "List",
+    type: "ceaaInvolvements",
+    legislation: 2002,
+    name: "Screening - Confirmed",
+    listOrder: 50
+  },
+  {
+    _schemaName: "List",
+    type: "ceaaInvolvements",
+    legislation: 2002,
+    name: "Substituted",
+    listOrder: 60
+  },
+  {
+    _schemaName: "List",
+    type: "ceaaInvolvements",
+    legislation: 2002,
+    name: "Substituted (Provincial Lead)",
+    listOrder: 70
+  },
+  {
+    _schemaName: "List",
+    type: "ceaaInvolvements",
+    legislation: 2002,
+    name: "Comprehensive Study",
+    listOrder: 80
+  },
+  {
+    _schemaName: "List",
+    type: "ceaaInvolvements",
+    legislation: 2002,
+    name: "Comprehensive Study - Unconfirmed",
+    listOrder: 90
+  },
+  {
+    _schemaName: "List",
+    type: "ceaaInvolvements",
+    legislation: 2002,
+    name: "Comprehensive Study - Confirmed'",
+    listOrder: 100
+  },
+  {
+    _schemaName: "List",
+    type: "ceaaInvolvements",
+    legislation: 2002,
+    name: "Comprehensive Study (Pre CEAA 2012)",
+    listOrder: 110
+  },
+  {
+    _schemaName: "List",
+    type: "ceaaInvolvements",
+    legislation: 2002,
+    name: "Comp Study",
+    listOrder: 120
+  },
+  {
+    _schemaName: "List",
+    type: "ceaaInvolvements",
+    legislation: 2002,
+    name: "Comp Study - Unconfirmed",
+    listOrder: 130
+  },
+  {
+    _schemaName: "List",
+    type: "ceaaInvolvements",
+    legislation: 2002,
+    name: "To be determined",
+    listOrder: 140
+  },
+  {
+    _schemaName: "List",
+    type: "ceaaInvolvements",
+    legislation: 2002,
+    name: "Equivalent - NEB",
+    listOrder: 150
+  },
+  {
+    _schemaName: "List",
+    type: "ceaaInvolvements",
+    legislation: 2018,
+    name: "Substitution",
+    listOrder: 160
+  },
+  {
+    _schemaName: "List",
+    type: "ceaaInvolvements",
+    legislation: 2018,
+    name: "Coordination",
+    listOrder: 170
+  },
+  {
+    _schemaName: "List",
+    type: "ceaaInvolvements",
+    legislation: 2018,
+    name: "Joint Review Panel",
+    listOrder: 180
+  },
+  {
+    _schemaName: "List",
+    type: "ceaaInvolvements",
+    legislation: 2018,
+    name: "Substituted to CER",
+    listOrder: 190
+  },
+  ////// EA Decisions ////////
+  {
+    _schemaName: "List",
+    type: "eaDecisions",
+    legislation: 2002,
+    name: "In Progress",
+    listOrder: 0
+  },
+  {
+    _schemaName: "List",
+    type: "eaDecisions",
+    legislation: 2002,
+    name: "Certificate Issued",
+    listOrder: 10
+  },
+  {
+    _schemaName: "List",
+    type: "eaDecisions",
+    legislation: 2002,
+    name: "Certificate Refused",
+    listOrder: 20
+  },
+  {
+    _schemaName: "List",
+    type: "eaDecisions",
+    legislation: 2002,
+    name: "Certificate Not Required",
+    listOrder: 30
+  },
+  {
+    _schemaName: "List",
+    type: "eaDecisions",
+    legislation: 2002,
+    name: "Certificate Expired",
+    listOrder: 40
+  },
+  {
+    _schemaName: "List",
+    type: "eaDecisions",
+    legislation: 2002,
+    name: "Withdrawn",
+    listOrder: 50
+  },
+  {
+    _schemaName: "List",
+    type: "eaDecisions",
+    legislation: 2002,
+    name: "Terminated",
+    listOrder: 60
+  },
+  {
+    _schemaName: "List",
+    type: "eaDecisions",
+    legislation: 2002,
+    name: "Pre-EA Act Approval",
+    listOrder: 70
+  },
+  {
+    _schemaName: "List",
+    type: "eaDecisions",
+    legislation: 2002,
+    name: "Not Designated Reviewable",
+    listOrder: 80
+  },
+  {
+    _schemaName: "List",
+    type: "eaDecisions",
+    legislation: 2018,
+    name: "In Progress",
+    listOrder: 90
+  },
+  {
+    _schemaName: "List",
+    type: "eaDecisions",
+    legislation: 2018,
+    name: "Exemption Order",
+    listOrder: 100
+  },
+  {
+    _schemaName: "List",
+    type: "eaDecisions",
+    legislation: 2018,
+    name: "Assessment Terminated",
+    listOrder: 110
+  },
+  {
+    _schemaName: "List",
+    type: "eaDecisions",
+    legislation: 2018,
+    name: "Application Withdrawn",
+    listOrder: 120
+  },
+  {
+    _schemaName: "List",
+    type: "eaDecisions",
+    legislation: 2018,
+    name: "Certificate Issued",
+    listOrder: 130
+  },
+  {
+    _schemaName: "List",
+    type: "eaDecisions",
+    legislation: 2018,
+    name: "Certificate Refused",
+    listOrder: 140
+  },
+  {
+    _schemaName: "List",
+    type: "eaDecisions",
+    legislation: 2018,
+    name: "Certificate Cancelled",
+    listOrder: 150
+  },
+  {
+    _schemaName: "List",
+    type: "eaDecisions",
+    legislation: 2018,
+    name: "Certificate Expired",
+    listOrder: 160
+  },
+  {
+    _schemaName: "List",
+    type: "eaDecisions",
+    legislation: 2018,
+    name: "Exemption Order Rescinded",
+    listOrder: 170
+  },
+  {
+    _schemaName: "List",
+    type: "eaDecisions",
+    legislation: 2018,
+    name: "Certificate Reinstated",
+    listOrder: 180
+  },
+  {
+    _schemaName: "List",
+    type: "eaDecisions",
+    legislation: 2018,
+    name: "Readiness Termination",
+    listOrder: 190
+  },
+  {
+    _schemaName: "List",
+    type: "eaDecisions",
+    legislation: 2018,
+    name: "Project Designated Non-Reviewable",
+    listOrder: 200
+  },
+  {
+    _schemaName: "List",
+    type: "eaDecisions",
+    legislation: 2018,
+    name: "Certificate End of Life'",
+    listOrder: 210
+  }
+];

--- a/migrations_data/eaDecisionsAndIAACInvolvment.js
+++ b/migrations_data/eaDecisionsAndIAACInvolvment.js
@@ -74,7 +74,7 @@ module.exports = [
     _schemaName: "List",
     type: "ceaaInvolvements",
     legislation: 2002,
-    name: "Comprehensive Study - Confirmed'",
+    name: "Comprehensive Study - Confirmed",
     listOrder: 100
   },
   {

--- a/migrations_data/eaDecisionsAndIAACInvolvment.js
+++ b/migrations_data/eaDecisionsAndIAACInvolvment.js
@@ -207,92 +207,99 @@ module.exports = [
   {
     _schemaName: "List",
     type: "eaDecisions",
-    legislation: 2018,
-    name: "In Progress",
+    legislation: 2002,
+    name: "Further Assessment Required",
     listOrder: 90
   },
   {
     _schemaName: "List",
     type: "eaDecisions",
     legislation: 2018,
-    name: "Exemption Order",
+    name: "In Progress",
     listOrder: 100
   },
   {
     _schemaName: "List",
     type: "eaDecisions",
     legislation: 2018,
-    name: "Assessment Terminated",
+    name: "Exemption Order",
     listOrder: 110
   },
   {
     _schemaName: "List",
     type: "eaDecisions",
     legislation: 2018,
-    name: "Application Withdrawn",
+    name: "Assessment Terminated",
     listOrder: 120
   },
   {
     _schemaName: "List",
     type: "eaDecisions",
     legislation: 2018,
-    name: "Certificate Issued",
+    name: "Application Withdrawn",
     listOrder: 130
   },
   {
     _schemaName: "List",
     type: "eaDecisions",
     legislation: 2018,
-    name: "Certificate Refused",
+    name: "Certificate Issued",
     listOrder: 140
   },
   {
     _schemaName: "List",
     type: "eaDecisions",
     legislation: 2018,
-    name: "Certificate Cancelled",
+    name: "Certificate Refused",
     listOrder: 150
   },
   {
     _schemaName: "List",
     type: "eaDecisions",
     legislation: 2018,
-    name: "Certificate Expired",
+    name: "Certificate Cancelled",
     listOrder: 160
   },
   {
     _schemaName: "List",
     type: "eaDecisions",
     legislation: 2018,
-    name: "Exemption Order Rescinded",
+    name: "Certificate Expired",
     listOrder: 170
   },
   {
     _schemaName: "List",
     type: "eaDecisions",
     legislation: 2018,
-    name: "Certificate Reinstated",
+    name: "Exemption Order Rescinded",
     listOrder: 180
   },
   {
     _schemaName: "List",
     type: "eaDecisions",
     legislation: 2018,
-    name: "Readiness Termination",
+    name: "Certificate Reinstated",
     listOrder: 190
   },
   {
     _schemaName: "List",
     type: "eaDecisions",
     legislation: 2018,
-    name: "Project Designated Non-Reviewable",
+    name: "Readiness Termination",
     listOrder: 200
   },
   {
     _schemaName: "List",
     type: "eaDecisions",
     legislation: 2018,
-    name: "Certificate End of Life'",
+    name: "Project Designated Non-Reviewable",
     listOrder: 210
+  },
+  {
+    _schemaName: "List",
+    type: "eaDecisions",
+    legislation: 2018,
+    name: "Certificate End of Life'",
+    listOrder: 220
   }
 ];


### PR DESCRIPTION
These changes will be breaking for the public and admin front ends. The following was changed:
- Updated Project model to use list IDs for EA Decisions and CEAA Involvement
- Added list terms for EA Decisions and CEAA Involvements
- Updated API endpoints to handle new relationships
- Created migrations to add new list terms and update all existing projects to use new IDs.

Note: The migration will fail on three projects as they have poor data.