### PR TITLE
EE-645 Add Partial Word Search

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -1,7 +1,7 @@
 {
     "env": {
         "commonjs": true,
-        "es6": false,
+        "es6": true,
         "node": true,
         "jest": true
     },

--- a/api/controllers/project.js
+++ b/api/controllers/project.js
@@ -76,6 +76,8 @@ var tagList = [
   'delete'
 ];
 
+const WORDS_TO_ANALYZE = 3;
+
 var getSanitizedFields = function (fields) {
   return _.remove(fields, function (f) {
     return (_.indexOf(tagList, f) !== -1);
@@ -408,6 +410,9 @@ exports.protectedPost = function (args, res, next) {
   projectData.proponent = mongoose.Types.ObjectId(obj.proponent);
   projectData.responsibleEPDId = mongoose.Types.ObjectId(obj.responsibleEPDId);
   projectData.projectLeadId = mongoose.Types.ObjectId(obj.projectLeadId);
+
+  // Generate search terms for the name.
+  projectData.nameSearchTerms = Utils.generateSearchTerms(obj.name, WORDS_TO_ANALYZE);
 
   // Define security tag defaults
   project.read = ['sysadmin', 'staff'];
@@ -1018,6 +1023,8 @@ exports.protectedPut = async function (args, res, next) {
   filteredData.decisionDate = projectObj.decisionDate ? new Date(projectObj.decisionDate) : null;
   fullProjectObject.review45Start = projectObj.review45Start  ? new Date(projectObj.review45Start) : null;
   fullProjectObject.review180Start = projectObj.review180Start  ? new Date(projectObj.review180Start) : null;
+
+  filteredData.nameSearchTerms = Utils.generateSearchTerms(projectObj.name, WORDS_TO_ANALYZE);
 
   try {
     filteredData.intake = {};

--- a/api/helpers/models/project.js
+++ b/api/helpers/models/project.js
@@ -28,6 +28,7 @@ var projectDataDefinition = {
   type                    : { type: String, default: '' },
   legislation             : { type: String, default: '' },
   legislationYear         : { type: Number },
+  nameSearchTerms         : [{ type: String }],
 
 
   //Everything else

--- a/api/helpers/utils.js
+++ b/api/helpers/utils.js
@@ -364,7 +364,7 @@ exports.generateSearchTerms = function (name, maxWordLimit) {
   }
 
   // Remove any duplicate terms by casting to a set and then back to an array.
-  const filteredTerms = [... new Set(searchTerms)];
+  const filteredTerms = [...new Set(searchTerms)];
   
   return filteredTerms;
 }

--- a/api/helpers/utils.js
+++ b/api/helpers/utils.js
@@ -345,3 +345,38 @@ exports.filterData = function (collection, data, roles) {
     return data;
   }
 }
+
+// Generates all unique search terms up to a word limit.
+exports.generateSearchTerms = function (name, maxWordLimit) {
+  if (!name) {
+    return;
+  }
+
+  let searchTerms = []
+
+  // Split the name into words.
+  const words = name.trim().split(/\s+/);
+  const wordLimit = words.length < maxWordLimit ? words.length : maxWordLimit;
+
+  for (let i = 0; i < wordLimit; i++) {
+    const wordTerms = getWordSearchTerms(words[i]);
+    searchTerms = [...searchTerms, ...wordTerms];
+  }
+
+  // Remove any duplicate terms by casting to a set and then back to an array.
+  const filteredTerms = [... new Set(searchTerms)];
+  
+  return filteredTerms;
+}
+
+// Gets all search terms for a single word.
+const getWordSearchTerms = (word) => {
+  const searchTerms = [];
+
+  // Start terms at 2 letters in length. Do not want to search on single letter.
+  for (let i = 2; i <= word.length; i++) {
+    searchTerms.push(word.substring(0, i));
+  }
+
+  return searchTerms;
+}

--- a/api/test/generate-data/model_change_watcher_hash.json
+++ b/api/test/generate-data/model_change_watcher_hash.json
@@ -50,7 +50,7 @@
     },
     {
       "name": "project.js",
-      "hash": "Go/vsSNrmBS84a9Lh+S/lxUAbJ4="
+      "hash": "J8Gff/30dN6mCqpOzMv3/L35xRU="
     },
     {
       "name": "recentActivity.js",

--- a/api/test/tests/helpers/utils.test.js
+++ b/api/test/tests/helpers/utils.test.js
@@ -29,4 +29,18 @@ describe('Helper Testing - utils', () => {
     expect(testRecord.performedBy).toBe(testUser);
     done();
   });
+
+  test('Generate search terms for all words - `generateSearchTerms`', async (done) => {
+    const testSentence = 'test three words';
+    const wordsToProcess = 3;
+
+    // Word search terms start at two.
+    const expectedResults = ['te', 'tes', 'test', 'th', 'thr', 'thre', 'three', 'wo', 'wor', 'word', 'words'];
+
+    const searchTerms = utils.generateSearchTerms(testSentence, wordsToProcess);
+
+    expect(searchTerms).toHaveLength(expectedResults.length);
+    expect(searchTerms).toEqual(expectedResults);
+    done();
+  });
 });

--- a/migrations/20200116825964-addProjectNgrams.js
+++ b/migrations/20200116825964-addProjectNgrams.js
@@ -1,0 +1,142 @@
+'use strict';
+
+const mongoose = require('mongoose');
+
+let dbm;
+let type;
+let seed;
+
+// Maximum number of words to create search terms for in a project's name.
+const WORDS_TO_ANALYZE = 3;
+
+/**
+  * We receive the dbmigrate dependency from dbmigrate initially.
+  * This enables us to not have to rely on NODE_PATH.
+  */
+exports.setup = function(options, seedLink) {
+  dbm = options.dbmigrate;
+  type = dbm.dataType;
+  seed = seedLink;
+};
+
+exports.up = function(db) {
+  let mClient;
+
+  return db.connection.connect(db.connectionString, { native_parser: true })
+    .then(async (client) => {
+      const updatePromises = [];
+      mClient = client;
+      
+      const collection = mClient.collection('epic');
+
+      // Get all projects.
+      const projects = await collection.aggregate([
+        { $match: { _schemaName: 'Project' } }
+      ])
+      .toArray();
+
+      projects.forEach(project => {
+        if (project.legislation_1996) {
+          const searchTerms = generateSearchTerms(project.legislation_1996.name, WORDS_TO_ANALYZE);
+
+          updatePromises.push(
+            collection.update(
+              {
+                _id: project._id
+              },
+              {
+                $set: {
+                  'legislation_1996.nameSearchTerms': searchTerms,
+                }
+              }
+            )
+          );
+        }
+
+        if (project.legislation_2002) {
+          const searchTerms = generateSearchTerms(project.legislation_2002.name, WORDS_TO_ANALYZE);
+
+          updatePromises.push(
+            collection.update(
+              {
+                _id: project._id
+              },
+              {
+                $set: {
+                  'legislation_2002.nameSearchTerms': searchTerms,
+                }
+              }
+            )
+          );
+        }
+
+        if (project.legislation_2018) {
+          const searchTerms = generateSearchTerms(project.legislation_2018.name, WORDS_TO_ANALYZE);
+
+          updatePromises.push(
+            collection.update(
+              {
+                _id: project._id
+              },
+              {
+                $set: {
+                  'legislation_2018.nameSearchTerms': searchTerms,
+                }
+              }
+            )
+          );
+        }
+      });
+
+      // Wait for all promises to resolve before closing the DB connection.
+      await Promise.all(updatePromises);
+
+      mClient.close();
+    })
+    .catch((e) => {
+      console.log('e:', e);
+      mClient.close();
+    });
+};
+  
+exports.down = function(db) {
+  return null;
+};
+
+exports._meta = {
+  'version': 1
+};
+
+// Generates all unique search terms up to a word limit.
+const generateSearchTerms = (name, maxWordLimit) => {
+  if (!name) {
+    return;
+  }
+
+  let searchTerms = []
+
+  // Split the name into words.
+  const words = name.trim().split(/\s+/);
+  const wordLimit = words.length < maxWordLimit ? words.length : maxWordLimit;
+
+  for (let i = 0; i < wordLimit; i++) {
+    const wordTerms = getWordSearchTerms(words[i]);
+    searchTerms = [...searchTerms, ...wordTerms];
+  }
+
+  // Remove any duplicate terms by casting to a set and then back to an array.
+  const filteredTerms = [... new Set(searchTerms)];
+  
+  return filteredTerms;
+}
+
+// Gets all search terms for a single word.
+const getWordSearchTerms = (word) => {
+  const searchTerms = [];
+
+  for (let i = 1; i <= word.length; i++) {
+    searchTerms.push(word.substring(0, i));
+  }
+
+  return searchTerms;
+}

--- a/migrations/20200116825964-addProjectNgrams.js
+++ b/migrations/20200116825964-addProjectNgrams.js
@@ -134,7 +134,8 @@ const generateSearchTerms = (name, maxWordLimit) => {
 const getWordSearchTerms = (word) => {
   const searchTerms = [];
 
-  for (let i = 1; i <= word.length; i++) {
+  // Start terms at 2 letters in length. Do not want to search on single letter.
+  for (let i = 2; i <= word.length; i++) {
     searchTerms.push(word.substring(0, i));
   }
 

--- a/migrations/20200116984039-updateDocumentIndexs.js
+++ b/migrations/20200116984039-updateDocumentIndexs.js
@@ -1,0 +1,119 @@
+'use strict';
+
+var dbm;
+var type;
+var seed;
+
+/**
+  * We receive the dbmigrate dependency from dbmigrate initially.
+  * This enables us to not have to rely on NODE_PATH.
+  */
+exports.setup = function(options, seedLink) {
+  dbm = options.dbmigrate;
+  type = dbm.dataType;
+  seed = seedLink;
+};
+
+exports.up = function(db) {
+  let mClient;
+  return db.connection.connect(db.connectionString, { native_parser: true})
+    .then(async function(mClientInst, callback) {
+      mClient = mClientInst;
+      var epicCollection = mClient.collection('epic');
+      // drop existing index, see dbFieldClean migration
+      await dropProjectIndex(epicCollection)
+      // apply index to capture embedded project data structure
+      await applyCustomFullTextSearchIndex(epicCollection)
+      mClient.close()
+    })
+};
+
+async function dropProjectIndex(epicCollection) {
+  return new Promise(function(resolve, reject) {
+    console.log("Dropping existing index on projects")
+    resolve(epicCollection.dropIndex("searchIndex_EAR_1"))
+  })
+}
+
+async function applyCustomFullTextSearchIndex(targetCollection) {
+  return new Promise(function(resolve, reject) {
+    console.log("applying multifield custom FTS index");
+    resolve(targetCollection.createIndex( {
+      // projects
+      "legislation_1996.name": "text",
+      "legislation_2002.name": "text",
+      "legislation_2018.name": "text",
+      "legislation_1996.eacDecision": "text",
+      "legislation_2002.eacDecision": "text",
+      "legislation_2018.eacDecision": "text",
+      "legislation_1996.location": "text",
+      "legislation_2002.location": "text",
+      "legislation_2018.location": "text",
+      "legislation_1996.region": "text",
+      "legislation_2002.region": "text",
+      "legislation_2018.region": "text",
+      "legislation_1996.commodity": "text",
+      "legislation_2002.commodity": "text",
+      "legislation_2018.commodity": "text",
+      "legislation_1996.type": "text",
+      "legislation_2002.type": "text",
+      "legislation_2018.type": "text",
+      "legislation_1996.epicProjectId": "text",
+      "legislation_2002.epicProjectId": "text",
+      "legislation_2018.epicProjectId": "text",
+      "legislation_1996.sector": "text",
+      "legislation_2002.sector": "text",
+      "legislation_2018.sector": "text",
+      "legislation_1996.status": "text",
+      "legislation_2002.status": "text",
+      "legislation_2018.status": "text",
+      "legislation_1996.code": "text",
+      "legislation_2002.code": "text",
+      "legislation_2018.code": "text",
+      "legislation_1996.nameSearchTerms": "text",
+      "legislation_2002.nameSearchTerms": "text",
+      "legislation_2018.nameSearchTerms": "text",
+      // documents
+      name: "text",
+      displayName: "text",
+      description: "text",
+      labels: "text",
+      documentFileName: "text",
+      documentAuthor: "text",
+      //recentActivity
+      headline: "text",
+      content: "text",
+      //user
+      orgName: "text"
+     },
+      {
+        weights: {
+          "legislation_1996.nameSearchTerms": 9500,
+          "legislation_2002.nameSearchTerms": 9500,
+          "legislation_2018.nameSearchTerms": 9500,
+          "legislation_1996.name": 9000,
+          "legislation_2002.name": 9000,
+          "legislation_2018.name": 9000,
+          name: 9000,
+          displayName: 8500,
+          description: 8000,
+          labels: 6000,
+          documentFileName: 5000,
+          documentAuthor: 3000,
+          headline: 1,
+          content: 1,
+          orgName: 1,
+        },
+        name: "searchIndex_EAR_1"
+      }
+    ));
+  });
+};
+
+exports.down = function(db) {
+  return null;
+};
+
+exports._meta = {
+  "version": 1
+};


### PR DESCRIPTION
This change allows users to search partial words over a project's name. This was accomplished by creating search terms for the name that are stored on the project. 

- Creates a migration to add search terms to all existing projects
- Creates a migration to add new indexes over the name search terms
- Updates project adding and updating so that new search terms are added to the project
- Adds unit test for the new utility function