### PR TITLE
setting the ceaa and eac fields to be set on saving

### DIFF
--- a/api/controllers/project.js
+++ b/api/controllers/project.js
@@ -410,7 +410,11 @@ exports.protectedPost = function (args, res, next) {
   projectData.proponent = mongoose.Types.ObjectId(obj.proponent);
   projectData.responsibleEPDId = mongoose.Types.ObjectId(obj.responsibleEPDId);
   projectData.projectLeadId = mongoose.Types.ObjectId(obj.projectLeadId);
-
+  
+  // Also need to make sure that the eacDecision and CEAAInvolvement fields are in the project. Hard requirement for public
+  projectData.CEAAInvolvement = obj.CEAAInvolvement ? obj.CEAAInvolvement : null;
+  projectData.eacDecision = obj.eacDecision ? obj.eacDecision : null;
+  
   // Generate search terms for the name.
   projectData.nameSearchTerms = Utils.generateSearchTerms(obj.name, WORDS_TO_ANALYZE);
 

--- a/api/helpers/utils.js
+++ b/api/helpers/utils.js
@@ -184,7 +184,10 @@ exports.runDataQuery = async function (modelType, role, query, fields, sortWarmU
           }
         },
         (modelType === 'Project') && {
-          "$unwind": "$CEAAInvolvement"
+          "$unwind": {
+            "path": "$CEAAInvolvement",
+            "preserveNullAndEmptyArrays": true
+          }
         },
         (modelType === 'Project') && {
           '$lookup': {
@@ -195,7 +198,10 @@ exports.runDataQuery = async function (modelType, role, query, fields, sortWarmU
           }
         },
         (modelType === 'Project') && {
-          "$unwind": "$eacDecision"
+          "$unwind": {
+            "path": "$eacDecision",
+            "preserveNullAndEmptyArrays": true
+          }
         },
         //Unpack the default key inside a nested call with project data
          // To unpack the legislation data into the project key


### PR DESCRIPTION
also preserving null on the query on those fields when we grab the project. This makes the loading of projects on public not hard quit