### PR TITLE
Update PVC to netapp from gluster

### DIFF
--- a/openshift/templates/api-minio.dc.yaml
+++ b/openshift/templates/api-minio.dc.yaml
@@ -100,8 +100,8 @@ objects:
     metadata:
       name: ${NAME}-docs
       annotations:
-        volume.beta.kubernetes.io/storage-class: gluster-file
-        volume.beta.kubernetes.io/storage-provisioner: kubernetes.io/glusterfs
+        volume.beta.kubernetes.io/storage-class: netapp-file-standard
+        volume.beta.kubernetes.io/storage-provisioner: kubernetes.io/netapp
     spec:
       accessModes:
       - ReadWriteOnce


### PR DESCRIPTION
The Kamloops cluster changed it's PVC provisioning rules so gluster-fs can no longer be deployed new (it is being allowed to be grandfathered in place though).  Going forward templates being run must select netapp instead of gluster.