### PR TITLE
Adding await for attachFeatureDocuments

### DIFF
--- a/api/controllers/project.js
+++ b/api/controllers/project.js
@@ -292,7 +292,7 @@ exports.protectedGet = async function (args, res, next) {
     serializeProjectVirtuals(data);
 
     // attach projects featuredDocument IDs
-    data = Utils.attachFeaturedDocuments(data);
+    data = await Utils.attachFeaturedDocuments(data);
 
     defaultLog.info('Got comment project(s):', data);
     return Actions.sendResponse(res, 200, data);


### PR DESCRIPTION
Re-adding a small change that looks like it was squashed at some point. This is related to [EE-807](https://bcmines.atlassian.net/browse/EE-807) as the return from the projects endpoint was a promise, which caused the activity page to spin. This issue will cause errors in other places the endpoint is hit as well, so the fix will likely prevent other similar errors from popping up in the future