### PR TITLE
Removed hardcoded active=true on bool params

### DIFF
--- a/api/helpers/aggregators.js
+++ b/api/helpers/aggregators.js
@@ -314,28 +314,19 @@ const handleProjectTerms = (item) => {
 const getConvertedValue = (item, entry) => {
   if (isNaN(entry)) {
     if (isValidObjectId(entry)) {
-      console.log("objectid");
       // ObjectID
       return { [item]: mongoose.Types.ObjectId(entry) };
-    } else if (entry === 'true') {
-      console.log("bool");
-      // Bool
+    } else if (entry.toLowerCase() === 'true') {
       const tempObj = {};
       tempObj[item] = true;
       return tempObj;
-    } else if (entry === 'false') {
-      console.log("bool");
-      // Bool
-      console.log("bool");
-      // Bool
+    } else if (entry.toLowerCase() === 'false') {
       const tempObj = {};
       tempObj[item] = false;
     } else {
-      console.log("string");
       return { [item]: entry };
     }
   } else {
-    console.log("number");
     return { [item]: parseInt(entry) };
   }
 };

--- a/api/helpers/aggregators.js
+++ b/api/helpers/aggregators.js
@@ -322,12 +322,14 @@ const getConvertedValue = (item, entry) => {
       // Bool
       const tempObj = {};
       tempObj[item] = true;
-      tempObj.active = true;
       return tempObj;
     } else if (entry === 'false') {
       console.log("bool");
       // Bool
-      return { [item]: false };
+      console.log("bool");
+      // Bool
+      const tempObj = {};
+      tempObj[item] = false;
     } else {
       console.log("string");
       return { [item]: entry };


### PR DESCRIPTION
Any Query param that was a boolean would also be hardwired to include activity: true, which was breaking mongo queries. This value appears to have been a legacy value from news items, and the fix is in because it was preventing querying documents by isFeatured