### PR TITLE
Re-add decodeURIComponent fix for query filters

### DIFF
--- a/api/helpers/aggregators.js
+++ b/api/helpers/aggregators.js
@@ -221,7 +221,7 @@ const generateExpArray = async (field, roles, schemaName) => {
     console.log("queryString:", queryString);
 
     await Promise.all(Object.keys(queryString).map(async item => {
-      const entry = queryString[item];
+      const entry = decodeURIComponent(queryString[item]);
       console.log("item:", item, entry);
       const orArray = [];
 


### PR DESCRIPTION
Looks like the decodeURIComponent fix for [EE-779](https://bcmines.atlassian.net/browse/EE-779) was blown away by a recent merge. Readding