### PR TITLE
Preventing null sortField when empty second param exists

### DIFF
--- a/api/controllers/search.js
+++ b/api/controllers/search.js
@@ -147,6 +147,10 @@ const executeQuery = async function (args, res) {
     }
   });
 
+  if (sortField === '') {
+    sortField = sortBy[0];
+  }
+  
   defaultLog.info("sortingValue:", sortingValue);
   defaultLog.info("sortField:", sortField);
   defaultLog.info("sortDirection:", sortDirection);


### PR DESCRIPTION
Fix for [EE-832](https://bcmines.atlassian.net/browse/EE-832), sortField will occasionally have an empty parameter, which is being stripped by some code above, but the sortField is not being set to the actual value of the field in these cases, which in turn prevents the sort aggregator from being added.