### PR TITLE
adding in null check on fileMeta

### DIFF
--- a/api/controllers/document.js
+++ b/api/controllers/document.js
@@ -317,6 +317,10 @@ exports.publicDownload = function (args, res, next) {
           .then(function (docURL) {
             Utils.recordAction('Download', 'Document', 'public', args.swagger.params.docId && args.swagger.params.docId.value ? args.swagger.params.docId.value : null);
             // stream file from Minio to client
+            // Size is undefined on related documents on pcps
+            if (!fileMeta) {
+              return
+            }
             res.setHeader('Content-Length', fileMeta.size);
             res.setHeader('Content-Type', fileMeta.metaData['content-type']);
             res.setHeader('Content-Disposition', 'attachment;filename="' + fileName + '"');
@@ -374,6 +378,9 @@ exports.protectedDownload = function (args, res, next) {
           .then(function (docURL) {
             Utils.recordAction('Download', 'Document', args.swagger.params.auth_payload.preferred_username, args.swagger.params.docId && args.swagger.params.docId.value ? args.swagger.params.docId.value : null);
             // stream file from Minio to client
+            if (!fileMeta) {
+              return
+            }
             res.setHeader('Content-Length', fileMeta.size);
             res.setHeader('Content-Type', fileMeta.metaData['content-type']);
             res.setHeader('Content-Disposition', 'attachment;filename="' + fileName + '"');


### PR DESCRIPTION
Returning on null of fileMeta which is caused when minio cannot find the file. This should propagate into a 404