### PR TITLE
Get group member now sorts

### DIFF
--- a/api/controllers/project.js
+++ b/api/controllers/project.js
@@ -864,17 +864,15 @@ handleGetGroupMembers = async function (groupId, roles, sortBy, pageSize, pageNu
       // Sort
       if (sortBy && sortBy.value) {
         sort = {};
-        sortBy.value.forEach(function (value) {
-          var order_by = value.charAt(0) == '-' ? -1 : 1;
-          var sort_by = value.slice(1);
-          sort[sort_by] = order_by;
-        }, this);
+        var order_by = sortBy.value.charAt(0) == '-' ? -1 : 1;
+        var sort_by = sortBy.value.slice(1);
+        sort[sort_by] = order_by;
       }
 
       // Skip and limit
       var processedParameters = Utils.getSkipLimitParameters(pageSize, pageNum);
       skip = processedParameters.skip;
-      limit = processedParameters.limit;
+      limit = parseInt(processedParameters.limit);
 
       fields = ['_id', 'displayName', 'email', 'org', 'orgName', 'phoneNumber'];
       try {

--- a/api/swagger/swagger.yaml
+++ b/api/swagger/swagger.yaml
@@ -1986,6 +1986,21 @@ paths:
             type: string
             required: true
             description: "Get Group."
+          - name: sortBy
+            in: query
+            type: string
+            required: true
+            description: "Group corresponding to a project."
+          - name: pageSize
+            in: query
+            type: string
+            required: true
+            description: "Get Group."
+          - name: pageNum
+            in: query
+            type: string
+            required: true
+            description: "Get Group."
       responses:
         "200":
           description: "Success"


### PR DESCRIPTION
Group member API get was ignoring passed in sort parameters.

See ticket [EE-289](https://bcmines.atlassian.net/browse/EE-289)