### PR TITLE
Adding github action scripts

### DIFF
--- a/.github/workflows/pull_request_master.yml
+++ b/.github/workflows/pull_request_master.yml
@@ -1,0 +1,24 @@
+# This action will create a Pull Request to merge all changes on TEST
+# into the MASTER branch. PR will be created as a draft
+name: Create master branch PR
+
+on:
+  pull_request:
+    branches:
+    - test
+    types: [closed]
+
+jobs:
+  pull-request:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v1
+    - name: pull-request
+      uses: repo-sync/pull-request@v2
+      with:
+        destination_branch: "master"
+        pr_title: "Pulling ${{ github.ref }} into MASTER"
+        pr_body: ":crown: *An automated PR*  This PR will pull all recent merges from TEST into MASTER"
+        pr_label: "auto-pr from test to master" 
+        pr_draft: true
+        github_token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/pull_request_test.yml
+++ b/.github/workflows/pull_request_test.yml
@@ -1,0 +1,24 @@
+# This action will create a Pull Request to merge all changes on DEVELOP
+# into the TEST branch. PR will be created as a draft
+name: Create test branch PR
+
+on:
+  pull_request:
+    branches:
+    - develop
+    types: [closed]
+
+jobs:
+  pull-request:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v1
+    - name: pull-request
+      uses: repo-sync/pull-request@v2
+      with:
+        destination_branch: "test"
+        pr_title: "Pulling ${{ github.ref }} into TEST"
+        pr_body: ":crown: *An automated PR*  This PR will pull all recent merges from DEVELOP into TEST"
+        pr_label: "auto-pr from dev to test"
+        pr_draft: true
+        github_token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
Creating actions to automatically create PR's for our test and master branches.

When a PR is merged into develop, a new PR is created to merge into test. If a PR exists in test, it should be updated with the merge. The same process is true for master. Once a test PR is merged, a master branch PR will be created.

PR's are not assigned (we can add an assignment/reviewer list if needed)
PR's are created as drafts initially.

Note: The message/title are fairly generic at the moment. Any suggestions for improvements, let me know.