### PR TITLE
Implement Data Generators in Dev

### DIFF
--- a/Jenkinsfile-develop
+++ b/Jenkinsfile-develop
@@ -227,5 +227,40 @@ pipeline {
         }
       }
     }
+
+    stage('Populate Data'){
+      steps {
+        script {
+          try {
+            echo "Clearing old data"
+             /* Get the Deployment Config (DC) Object */
+            def dcObj = openshift.selector('dc', 'eagle-api').object()
+            
+            /* Use the DC to find the pods */
+            def podSelector = openshift.selector('pod', [deployment: "eagle-api-${dcObj.status.latestVersion}"])
+            
+            podSelector.withEach {
+                // obtain the pod name and remove "pods/" from the front.
+                def podName = it.name()  // probably pods/abcd1234
+                podName = podName.replaceFirst("pods/", "")
+
+                // Run a command on the container
+                def resp = openshiftExec(pod: podName, command: ["echo", "testing"])
+
+                assert resp.stdout.contains("testing")              
+            }
+
+            echo "Populating new data"
+          } catch (error) {
+            notifyRocketChat(
+              "@all Data generation failed for the build ${env.BUILD_DISPLAY_NAME} of eagle-api.\n ${env.RUN_DISPLAY_URL}\n Error: \n ${error.message}",
+              ROCKET_DEPLOY_WEBHOOK
+            )
+            currentBuild.result = "FAILURE"
+            throw new Exception("Data generation failed")
+          }
+        }
+      }
+    }
   }
 }

--- a/Jenkinsfile-develop
+++ b/Jenkinsfile-develop
@@ -245,7 +245,7 @@ pipeline {
                 podName = podName.replaceFirst("pods/", "")
 
                 // Run a command in the container
-                def resp = openshiftExec(pod: podName, command: ["/opt/app-root/src/generate.sh", "30", "Static", "Saved"])
+                def resp = openshiftExec(pod: podName, command: ["/opt/app-root/src/generate.sh", "30", "Static", "Saved", "Single"])
             }
           } catch (error) {
             notifyRocketChat(

--- a/Jenkinsfile-develop
+++ b/Jenkinsfile-develop
@@ -164,7 +164,7 @@ pipeline {
                 ROCKET_QA_WEBHOOK = sh(returnStdout: true, script: 'cat rocket-qa-webhook')
 
                 echo "Building eagle-api develop branch"
-                openshiftBuild bldCfg: 'eagle-api', showBuildLogs: 'true'
+                openshiftBuild bldCfg: 'eagle-api', showBuildLogs: 'true', env: [[ name: "NODE_ENV", value: "development" ]]
                 echo "Build done"
 
                 echo ">>> Get Image Hash"
@@ -232,7 +232,7 @@ pipeline {
       steps {
         script {
           try {
-            echo "Clearing old data"
+            echo "Running data generators"
              /* Get the Deployment Config (DC) Object */
             def dcObj = openshift.selector('dc', 'eagle-api').object()
             
@@ -241,16 +241,12 @@ pipeline {
             
             podSelector.withEach {
                 // obtain the pod name and remove "pods/" from the front.
-                def podName = it.name()  // probably pods/abcd1234
+                def podName = it.name()
                 podName = podName.replaceFirst("pods/", "")
 
-                // Run a command on the container
-                def resp = openshiftExec(pod: podName, command: ["echo", "testing"])
-
-                assert resp.stdout.contains("testing")              
+                // Run a command in the container
+                def resp = openshiftExec(pod: podName, command: ["/opt/app-root/src/generate.sh", "30", "Static", "Saved"])
             }
-
-            echo "Populating new data"
           } catch (error) {
             notifyRocketChat(
               "@all Data generation failed for the build ${env.BUILD_DISPLAY_NAME} of eagle-api.\n ${env.RUN_DISPLAY_URL}\n Error: \n ${error.message}",

--- a/api/test/data_generators/generate.test.js
+++ b/api/test/data_generators/generate.test.js
@@ -26,17 +26,9 @@ describe('Generate Test Data', () => {
 
   describe('Generate Projects', () => {
     test('Generator', async done => {
-    mongoose.connection.db.collection('epic').count((error, count) => {
-      // This is a fail safe to prevent data being generated on databases that are not empty.
-      if (count) {
-        defaultLog.error(`Collection must be empty to generate data. There are currently ${count} documents in the collection`);
-        done();
-        return;
-      }
-
+    mongoose.connection.db.collection('epic').count((error, recordCount) => {
       test_helper.dataGenerationSettings.then(genSettings => {
         defaultLog.debug(genSettings);
-
         // Eaxample basic usage from project base dir: 
         //     ./generate.sh 10 Static Unsaved
         //     ./generate.sh 3 Random Saved
@@ -47,6 +39,14 @@ describe('Generate Test Data', () => {
         // and it will run a coverage test using settings 1 Static Unsaved
         if (genSettings.generate) {
           defaultLog.info("Data Generation is on");
+
+          // This is a fail safe to prevent data being generated on collections that have data if not explicitly set in the command.
+          if (recordCount && genSettings.single_db_pass) {
+            defaultLog.error(`Collection must be empty to generate data or the command must be run with the 'Multiple' flag set. There are currently ${recordCount} documents in the collection`);
+            done();
+            return;
+          }
+
           gh.generateEntireDatabase(usersData).then(generatedData => {
             defaultLog.info(((genSettings.generate_consistent_data) ? "Consistent" : "Random") + " data generation " + ((genSettings.save_to_persistent_mongo) ? "saved" : "unsaved"));
             let projects = generatedData.projects;

--- a/api/test/data_generators/generate.test.js
+++ b/api/test/data_generators/generate.test.js
@@ -10,6 +10,7 @@ Promise.config({
 });
 const test_helper = require('../test_helper');
 const factory_helper = require('../factories/factory_helper');
+const mongoose = require('mongoose');
 const request = require('supertest');
 const nock = require('nock');
 const gh = require("./generate_helper");
@@ -24,7 +25,15 @@ describe('Generate Test Data', () => {
   ];
 
   describe('Generate Projects', () => {
-    test('Generator', done => {
+    test('Generator', async done => {
+    mongoose.connection.db.collection('epic').count((error, count) => {
+      // This is a fail safe to prevent data being generated on databases that are not empty.
+      if (count) {
+        defaultLog.error(`Collection must be empty to generate data. There are currently ${count} documents in the collection`);
+        done();
+        return;
+      }
+
       test_helper.dataGenerationSettings.then(genSettings => {
         defaultLog.debug(genSettings);
 
@@ -72,6 +81,7 @@ describe('Generate Test Data', () => {
           done();
         }
       });
+     });
     });
   });
 });

--- a/api/test/factories/project_factory.js
+++ b/api/test/factories/project_factory.js
@@ -241,7 +241,7 @@ factory.define(factoryName, Project, buildOptions =>{
     
     let attrs = {
         _id                       : factory_helper.ObjectId()
-      , currentLegislationYear    : legislationNumber
+      , currentLegislationYear    : `legislation_${legislationNumber}`
       , legislationYearList       : legislationYearList
 
       // Permissions

--- a/api/test/repo_warden/model_vs_factory_hash.json
+++ b/api/test/repo_warden/model_vs_factory_hash.json
@@ -80,7 +80,7 @@
     },
     {
       "name": "cacUser_factory.js",
-       "hash": "WBXoC1oiPOQvym45OToJZrG9+n0="
+      "hash": "WBXoC1oiPOQvym45OToJZrG9+n0="
     },
     {
       "name": "comment_factory.js",
@@ -132,7 +132,7 @@
     },
     {
       "name": "project_factory.js",
-      "hash": "6r0XqupRI4oj9mbQ9Unb1Cy8hRg="
+      "hash": "gZB3ytPPKPi9QcDj1Gy9gNNEwvM="
     },
     {
       "name": "recent_activity_factory.js",

--- a/api/test/test_helper.js
+++ b/api/test/test_helper.js
@@ -90,6 +90,7 @@ function getDataGenerationSettings() {
       settingsObj.projects = Number(settingsObj.projects);
       settingsObj.save_to_persistent_mongo = ('Saved' == settingsObj.data_mode);
       settingsObj.generate_consistent_data = ('Static' == settingsObj.seed_mode);
+      settingsObj.single_db_pass = ('Single' == settingsObj.db_passes);
       settingsObj.generate = ('true' == settingsObj.generate);
       resolve(settingsObj);
     });
@@ -97,12 +98,14 @@ function getDataGenerationSettings() {
     return new Promise(resolve => {
       let data_mode = _.isEmpty(process.env.GENERATE_DATA_MODE) ? 'Unsaved' : process.env.GENERATE_DATA_MODE;
       let seed_mode = _.isEmpty(process.env.GENERATE_SEED_MODE) ? 'Static' : process.env.GENERATE_SEED_MODE;
+      let db_passes = _.isEmpty(process.env.GENERATE_DB_PASSES) ? 'Single' : process.env.GENERATE_DB_PASSES;
       let settingsObj = {
         data_mode: data_mode,
         seed_mode: seed_mode,
         projects: _.isEmpty(process.env.GENERATE_NUM_OF_PROJECTS) ? defaultNumberOfProjects : Number(process.env.GENERATE_NUM_OF_PROJECTS),
         save_to_persistent_mongo: ('Saved' == data_mode),
         generate_consistent_data: ('Static' == seed_mode),
+        single_db_pass: ('Single' == db_passes),
         generate: _.isEmpty(process.env.GENERATE_ON) ? false : ('true' == process.env.GENERATE_ON)
       };
       resolve(settingsObj);

--- a/generate.sh
+++ b/generate.sh
@@ -15,10 +15,15 @@ SEED_MODE="${default_deterministic_seed_mode}";
 default_transient_data_mode="Unsaved";
 persistent_data_mode="Saved";
 DATA_MODE="${default_transient_data_mode}";
-usage="\n./generate.sh [the number of projects to generate] [$default_deterministic_seed_mode (default) / $random_seed_mode] [$default_transient_data_mode (default) / $persistent_data_mode]\n\nExamples:\n./generate.sh 10 $default_deterministic_seed_mode $default_transient_data_mode\n./generate.sh 3 $random_seed_mode $persistent_data_mode\n\n";
+default_db_passes="Single";
+multiple_db_passes="Multiple";
+DB_PASSES="${default_db_passes}";
+usage="\n./generate.sh [the number of projects to generate] [$default_deterministic_seed_mode (default) / $random_seed_mode] [$default_transient_data_mode (default) / $persistent_data_mode] [$default_db_passes (default) / $multiple_db_passes]\n\nExamples:\n./generate.sh 10 $default_deterministic_seed_mode $default_transient_data_mode $default_db_passes\n./generate.sh 3 $random_seed_mode $persistent_data_mode $multiple_db_passes\n\n";
 valid_numeric_pattern='^[0-9]+$';
 valid_data_mode_pattern="^($default_transient_data_mode|$persistent_data_mode)+$";
 valid_seed_mode_pattern="^($default_deterministic_seed_mode|$random_seed_mode)+$";
+valid_db_passes_pattern="^($default_db_passes|$multiple_db_passes)+$";
+if [ ! -z "${4}" ]; then DB_PASSES=$4; fi
 if [ ! -z "${3}" ]; then DATA_MODE=$3; fi
 if [ ! -z "${2}" ]; then SEED_MODE=$2; fi
 if [ ! -z "${1}" ]; then PROJECTS=$1; fi
@@ -26,7 +31,8 @@ if [ ! -z "${1}" ]; then PROJECTS=$1; fi
 if ! [[ "${PROJECTS}" =~ $valid_numeric_pattern ]]; then printf "$usage"; exit 1; fi
 if ! [[ "${SEED_MODE}" =~ $valid_seed_mode_pattern ]]; then printf "$usage"; exit 1; fi
 if ! [[ "${DATA_MODE}" =~ $valid_data_mode_pattern ]]; then printf "$usage"; exit 1; fi
-JSON="{\"generate\":\"true\",\"projects\":\"$PROJECTS\",\"seed_mode\":\"$SEED_MODE\",\"data_mode\":\"$DATA_MODE\"}\n";
+if ! [[ "${DB_PASSES}" =~ $valid_db_passes_pattern ]]; then printf "$usage"; exit 1; fi
+JSON="{\"generate\":\"true\",\"projects\":\"$PROJECTS\",\"seed_mode\":\"$SEED_MODE\",\"data_mode\":\"$DATA_MODE\",\"db_passes\":\"$DB_PASSES\"}\n";
 #printf "$JSON\n";
 rm -f /tmp/generate.config;
 printf "$JSON" > /tmp/generate.config;


### PR DESCRIPTION
Ticket: https://bcmines.atlassian.net/browse/EE-649
Changes: This adds in the data generators as part of the dev pipeline. I have set it up so that they only run on an empty collection, which will work well when we get the PR based environments set up. This was to prevent any accidental data pollution in an environment like Prod.