### PR TITLE
update scl rh-nodejs version to match container node version

### DIFF
--- a/Jenkinsfile-develop
+++ b/Jenkinsfile-develop
@@ -247,7 +247,7 @@ pipeline {
                     podName = podName.replaceFirst("pod/", "")
 
                     // Run a command in the container
-                    openshift.exec("-n", "esm-dev", podName, "scl", "enable", "rh-nodejs8", '"/opt/app-root/src/generate.sh 20 Static Saved Single"')
+                    openshift.exec("-n", "esm-dev", podName, "scl", "enable", "rh-nodejs10", '"/opt/app-root/src/generate.sh 20 Static Saved Single"')
                 }
               }
             }


### PR DESCRIPTION
container is now built with a nodejs 10 base image, data gen scl call needs to match