### PR TITLE
PCP Query Fix

### DIFF
--- a/api/helpers/aggregators.js
+++ b/api/helpers/aggregators.js
@@ -339,11 +339,12 @@ const getConvertedValue = (item, entry) => {
 };
 
 const handlePCPItem = async (roles, expArray, value) => {
-  if (Array.isArray(value) || value.includes(',')) {
+  
+  if (!Array.isArray(value) && value.includes(',')) {
+    value = value.split(',');
+  }
 
-    if (value.includes(',')) {
-      value = value.split(',');
-    }
+  if (Array.isArray(value)) {
     // Arrays are a list of options so will always be ors
     const orArray = [];
     // Note that we need map and not forEach here because Promise.all uses

--- a/api/helpers/aggregators.js
+++ b/api/helpers/aggregators.js
@@ -339,7 +339,7 @@ const getConvertedValue = (item, entry) => {
 };
 
 const handlePCPItem = async (roles, expArray, value) => {
-  
+
   if (!Array.isArray(value) && value.includes(',')) {
     value = value.split(',');
   }

--- a/api/helpers/aggregators.js
+++ b/api/helpers/aggregators.js
@@ -339,7 +339,11 @@ const getConvertedValue = (item, entry) => {
 };
 
 const handlePCPItem = async (roles, expArray, value) => {
-  if (Array.isArray(value)) {
+  if (Array.isArray(value) || value.includes(',')) {
+
+    if (value.includes(',')) {
+      value = value.split(',');
+    }
     // Arrays are a list of options so will always be ors
     const orArray = [];
     // Note that we need map and not forEach here because Promise.all uses


### PR DESCRIPTION
Fix to correct PCP queries being ignored if more than one PCP value was selected.

Code was inadvertently checking PCP comma delimited strings as a single PCP value and unable to find a match in the switch. Updated code to use the array method if a comma is present, and splinting the value string into an array.

See ticket [EE-1055](https://bcmines.atlassian.net/browse/EE-1055)