### PR TITLE
Remove pragma no-cache header

### DIFF
--- a/app.js
+++ b/app.js
@@ -36,7 +36,6 @@ app.use(function (req, res, next) {
   res.setHeader('Cache-Control', 'max-age=4');
   // headers for zap scan issues
   res.setHeader('X-XSS-Protection', '1');
-  res.setHeader('Pragma', 'no-cache');
   res.setHeader('Strict-Transport-Security', 'max-age=63072000; includeSubDomains; preload');
   next();
 });


### PR DESCRIPTION
The Pragma no-cache header is causing issues when attempting to load word documents from minio. Removing the header will resolve the issue, but the Zap scan will start complaining about it again.

See issue [EE-1066](https://bcmines.atlassian.net/browse/EE-1066)