### PR TITLE
File backup, and restore templates

### DIFF
--- a/openshift/templates/jobs/minio-backup/minio-backup.cj.yaml
+++ b/openshift/templates/jobs/minio-backup/minio-backup.cj.yaml
@@ -52,7 +52,7 @@ objects:
           backoffLimit: 10
           template:
             spec:
-              activeDeadlineSeconds: 3600
+              activeDeadlineSeconds: 18000
               containers:
               - image: docker-registry.default.svc:5000/${TOOLS_NAMESPACE}/epic-documents-backup
                 imagePullPolicy: Always
@@ -62,12 +62,19 @@ objects:
                     valueFrom:
                       secretKeyRef:
                         key: RESTIC_PASSWORD
-                        name: minio-access-parameters-${NAME_SUFFIX}
+                        name: minio-restic-password-${NAME_SUFFIX}
                   - name: ROCKETCHAT_WEBHOOK
                     valueFrom:
                       secretKeyRef:
                         key: ROCKETCHAT_WEBHOOK
                         name: minio-rocketchat-webhook-${NAME_SUFFIX}
+                resources:
+                  limits:
+                    cpu: 2
+                    memory: 5Gi
+                  requests:
+                    cpu: 1
+                    memory: 2Gi
                 volumeMounts:
                 - mountPath: /mnt/dest/
                   name: dest

--- a/openshift/templates/jobs/minio-backup/minio-restore/Dockerfile
+++ b/openshift/templates/jobs/minio-backup/minio-restore/Dockerfile
@@ -3,12 +3,13 @@ USER root
 RUN apk add --update \
     curl rsync \
     && rm -rf /var/cache/apk/*
+
 # install restic
-CMD curl -Lo restic.bz2 https://github.com/restic/restic/releases/download/v0.9.4/restic_0.9.4_linux_amd64.bz2 \
+RUN curl -Lo restic.bz2 https://github.com/restic/restic/releases/download/v0.9.4/restic_0.9.4_linux_amd64.bz2 \
     && bzip2 -d restic.bz2 \
     && mv restic /usr/bin/restic \
-    && chmod +x /usr/bin/restic \
-    && sleep 1d
+    && chmod +x /usr/bin/restic
+
 COPY ./entrypoint.sh /
 ENTRYPOINT ["/entrypoint.sh"]
 USER 1001

--- a/openshift/templates/jobs/minio-backup/minio-restore/minio-restore.bc.yaml
+++ b/openshift/templates/jobs/minio-backup/minio-restore/minio-restore.bc.yaml
@@ -10,12 +10,12 @@ parameters:
   displayName: Git Repository URL
   description: The URL of the repository containing the code.
   required: false
-  value: https://github.com/maxwardle/eagle-api.git
+  value: https://github.com/bcgov/eagle-api.git
 - name: GIT_REF
   displayName: Git Reference
   description: Set this to a branch name, tag or other ref of your repository if you are not using the default branch.
   required: false
-  value: file-backup-template
+  value: develop
 - name: SOURCE_CONTEXT_DIR
   displayName: Source Context Directory
   description: The folder in the Git repo that contains the source code.

--- a/openshift/templates/jobs/minio-backup/minio-restore/minio-restore.bc.yaml
+++ b/openshift/templates/jobs/minio-backup/minio-restore/minio-restore.bc.yaml
@@ -10,12 +10,12 @@ parameters:
   displayName: Git Repository URL
   description: The URL of the repository containing the code.
   required: false
-  value: https://github.com/bcgov/eagle-api.git
+  value: https://github.com/maxwardle/eagle-api.git
 - name: GIT_REF
   displayName: Git Reference
   description: Set this to a branch name, tag or other ref of your repository if you are not using the default branch.
   required: false
-  value: develop
+  value: file-backup-template
 - name: SOURCE_CONTEXT_DIR
   displayName: Source Context Directory
   description: The folder in the Git repo that contains the source code.

--- a/openshift/templates/jobs/minio-backup/minio-restore/minio-restore.dc.yaml
+++ b/openshift/templates/jobs/minio-backup/minio-restore/minio-restore.dc.yaml
@@ -66,7 +66,7 @@ objects:
         - env:
           - name: SLEEP
             value: ${SLEEP_DURATION}
-          image: ""
+          image: docker-registry.default.svc:5000/${SOURCE_IMAGE_NAMESPACE}/${SOURCE_IMAGE_NAME}
           imagePullPolicy: Always
           name: ${NAME}
           resources: {}
@@ -84,6 +84,13 @@ objects:
         schedulerName: default-scheduler
         securityContext: {}
         terminationGracePeriodSeconds: 30
+        resources:
+          limits:
+            cpu: 2
+            memory: 5Gi
+          requests:
+            cpu: 1
+            memory: 2Gi
         volumes:
         - name: source-minio
           persistentVolumeClaim:


### PR DESCRIPTION
The backup cronjob template needed resource requests/ limits defined, and the restore deployment config's restic install was getting messed up. Everything should be working smoothly now and we should be able to restore our files from restic in an emergency. 