### PR TITLE
EE-1143: Rebuild project index

### DIFF
--- a/api/aggregators/searchAggregator.js
+++ b/api/aggregators/searchAggregator.js
@@ -107,8 +107,8 @@ exports.createKeywordRegexAggr = function(decodedKeywords, schemaName) {
     let searchTerm = terms.join('|');
 
     // By default, if we're doing a keyword search exclude
-    // any values that have a score less then 5000.
-    let regexMatch = { $match: { score: { $gt: 5000 } } };
+    // any values that have a score less then 0.5.
+    let regexMatch = { $match: { score: { $gt: 0.5 } } };
 
     let regex = { $regex:'(?:^|(?<= ))(' + searchTerm + ')(?:(?= )|$)', $options:'i' };
 

--- a/migrations/20200911202746-updateTextIndex.js
+++ b/migrations/20200911202746-updateTextIndex.js
@@ -1,0 +1,142 @@
+'use strict';
+
+var dbm;
+var type;
+var seed;
+
+/**
+  * We receive the dbmigrate dependency from dbmigrate initially.
+  * This enables us to not have to rely on NODE_PATH.
+  */
+exports.setup = function(options, seedLink) {
+  dbm = options.dbmigrate;
+  type = dbm.dataType;
+  seed = seedLink;
+};
+
+exports.up = function(db) {
+  let mClient;
+  return db.connection.connect(db.connectionString, { native_parser: true})
+    .then(async function(mClientInst, callback) {
+      mClient = mClientInst;
+      var epicCollection = mClient.collection('epic');
+      // drop existing index, see dbFieldClean migration
+      await dropProjectIndex(epicCollection)
+      // apply index to capture embedded project data structure
+      await applyCustomFullTextSearchIndex(epicCollection)
+      mClient.close()
+    })
+    
+};
+
+async function dropProjectIndex(epicCollection) {
+  return new Promise(function(resolve, reject) {
+    console.log("Dropping existing index on projects")
+    resolve(epicCollection.dropIndex("searchIndex_EAR_1"))
+  })
+}
+
+async function applyCustomFullTextSearchIndex(targetCollection) {
+  return new Promise(function(resolve, reject) {
+    console.log("applying multifield custom FTS index");
+    resolve(targetCollection.createIndex({
+      "description":"text",
+      "displayName":"text",
+      "documentAuthor":"text",
+      "documentFileName":"text",
+      "headline":"text",
+      "labels":"text",
+      "legislation_1996.code":"text",
+      "legislation_1996.commodity":"text",
+      "legislation_1996.eacDecision":"text",
+      "legislation_1996.epicProjectId":"text",
+      "legislation_1996.location":"text",
+      "legislation_1996.name":"text",
+      "legislation_1996.nameSearchTerms":"text",
+      "legislation_1996.region":"text",
+      "legislation_1996.sector":"text",
+      "legislation_1996.status":"text",
+      "legislation_1996.type":"text",
+      "legislation_2002.code":"text",
+      "legislation_2002.commodity":"text",
+      "legislation_2002.eacDecision":"text",
+      "legislation_2002.epicProjectId":"text",
+      "legislation_2002.location":"text",
+      "legislation_2002.name":"text",
+      "legislation_2002.nameSearchTerms":"text",
+      "legislation_2002.region":"text",
+      "legislation_2002.sector":"text",
+      "legislation_2002.status":"text",
+      "legislation_2002.type":"text",
+      "legislation_2018.code":"text",
+      "legislation_2018.commodity":"text",
+      "legislation_2018.eacDecision":"text",
+      "legislation_2018.epicProjectId":"text",
+      "legislation_2018.location":"text",
+      "legislation_2018.name":"text",
+      "legislation_2018.nameSearchTerms":"text",
+      "legislation_2018.region":"text",
+      "legislation_2018.sector":"text",
+      "legislation_2018.status":"text",
+      "legislation_2018.type":"text",
+      "name":"text",
+      "orgName":"text"
+   },
+   {
+      "weights":{
+         "content":1,
+         "description":8000,
+         "displayName":8500,
+         "documentAuthor":3000,
+         "documentFileName":5000,
+         "headline":1,
+         "labels":6000,
+         "legislation_1996.code":1,
+         "legislation_1996.commodity":1,
+         "legislation_1996.eacDecision":1,
+         "legislation_1996.epicProjectId":1,
+         "legislation_1996.location":1,
+         "legislation_1996.name":9000,
+         "legislation_1996.nameSearchTerms":9500,
+         "legislation_1996.region":1,
+         "legislation_1996.sector":1,
+         "legislation_1996.status":1,
+         "legislation_1996.type":1,
+         "legislation_2002.code":1,
+         "legislation_2002.commodity":1,
+         "legislation_2002.eacDecision":1,
+         "legislation_2002.epicProjectId":1,
+         "legislation_2002.location":1,
+         "legislation_2002.name":9000,
+         "legislation_2002.nameSearchTerms":9500,
+         "legislation_2002.region":1,
+         "legislation_2002.sector":1,
+         "legislation_2002.status":1,
+         "legislation_2002.type":1,
+         "legislation_2018.code":1,
+         "legislation_2018.commodity":1,
+         "legislation_2018.eacDecision":1,
+         "legislation_2018.epicProjectId":1,
+         "legislation_2018.location":1,
+         "legislation_2018.name":9000,
+         "legislation_2018.nameSearchTerms":9500,
+         "legislation_2018.region":1,
+         "legislation_2018.sector":1,
+         "legislation_2018.status":1,
+         "legislation_2018.type":1,
+         "name":9000,
+         "orgName":1
+      },
+      "name":"searchIndex_EAR_1",
+      "default_language":"none"
+   }));
+  });
+};
+
+exports.down = function(db) {
+  return null;
+};
+
+exports._meta = {
+  "version": 1
+};


### PR DESCRIPTION
Default language of English prevents some search terms from returning results. Specifically in our case, searching for "more" returns no results, rather then the expected result of More Creek Hydroelectric.

MongoDB supports text search for various languages. text indexes drop language-specific stop words (e.g. in English, “the”, “an”, “a”, “and”, etc.) and uses simple language-specific suffix stemming. We don't want this to happen for other words like "more",  so setting the index default language to "none" solves the issue.

See ticket [EE-1143](https://bcmines.atlassian.net/browse/EE-1143)

Also a small update to the search score threshold from `$gt: 5000` to `$gt: 0.5`. Our default weight for direct name searches is `1`, so a threshold of `5000` is way to high and can result in some searches (text only searches) returning nothing. For searches with advanced filters, it should have a negligible effect on results (probably 10-20 more on a search)

See ticket [EE-1131](https://bcmines.atlassian.net/browse/EE-1131)