### PR TITLE
FLCN-74 Update Jenkinsfiles for OCP4 pipeline

### DIFF
--- a/Jenkinsfile-cicd
+++ b/Jenkinsfile-cicd
@@ -79,7 +79,7 @@ def _openshift(String name, String project, Closure body) {
 def BUILD_DONE_STATUSES = ['Complete', 'Failed', 'Cancelled']
 pipeline {
   environment {
-    TOOLSPROJECT = "esm"
+    TOOLSPROJECT = "${TOOLS_NAMESPACE ?: '6cdc9e-tools'}"
   }
   agent any
   stages {
@@ -134,10 +134,10 @@ pipeline {
           }
           try {
             echo "Backing up..."
-            sh("oc tag esm/eagle-api:test esm/eagle-api:test-backup")
+            sh("oc tag ${TOOLSPROJECT}/eagle-api:test ${TOOLSPROJECT}/eagle-api:test-backup")
             sleep 5
             echo "Tagging Dev as Test..."
-            sh("oc tag esm/eagle-api:dev esm/eagle-api:test")
+            sh("oc tag ${TOOLSPROJECT}/eagle-api:dev ${TOOLSPROJECT}/eagle-api:test")
             sleep 5
 
             echo ">>>> Tagging Complete"
@@ -177,10 +177,10 @@ pipeline {
           }
           try {
             echo "Backing up..."
-            sh("oc tag esm/eagle-api:prod esm/eagle-api:prod-backup")
+            sh("oc tag ${TOOLSPROJECT}/eagle-api:prod ${TOOLSPROJECT}/eagle-api:prod-backup")
             sleep 5
             echo "Tagging Test as Prod..."
-            sh("oc tag esm/eagle-api:test esm/eagle-api:prod")
+            sh("oc tag ${TOOLSPROJECT}/eagle-api:test ${TOOLSPROJECT}/eagle-api:prod")
             sleep 5
             echo ">>>> Tagging Complete"
             notifyRocketChat(

--- a/Jenkinsfile-develop
+++ b/Jenkinsfile-develop
@@ -30,26 +30,30 @@ def notifyRocketChat(text, target) {
 
 // Create deployment status and pass to Jenkins-GitHub library
 void createDeploymentStatus (String suffix, String status) {
-  def ghDeploymentId = new GitHubHelper().createDeployment(
-    this,
-    "pull/${env.CHANGE_ID}/head",
-    [
-        'environment':"${suffix}",
-        'task':"deploy:pull:${env.CHANGE_ID}"
-    ]
-  )
+  try {
+    def ghDeploymentId = new GitHubHelper().createDeployment(
+      this,
+      "pull/${env.CHANGE_ID}/head",
+      [
+          'environment':"${suffix}",
+          'task':"deploy:pull:${env.CHANGE_ID}"
+      ]
+    )
 
-  new GitHubHelper().createDeploymentStatus(
-    this,
-    ghDeploymentId,
-    "${status}",
-    ['targetUrl':"https://eagle-${PR_NAME}-dev.pathfinder.gov.bc.ca/"]
-  )
+    new GitHubHelper().createDeploymentStatus(
+      this,
+      ghDeploymentId,
+      "${status}",
+      ['targetUrl':"https://eagle-${PR_NAME}-dev.${OCPHOST}/"]
+    )
 
-  if ('SUCCESS'.equalsIgnoreCase("${status}")) {
-    echo "${suffix} deployment successful!"
-  } else if ('PENDING'.equalsIgnoreCase("${status}")){
-    echo "${suffix} deployment pending."
+    if ('SUCCESS'.equalsIgnoreCase("${status}")) {
+      echo "${suffix} deployment successful!"
+    } else if ('PENDING'.equalsIgnoreCase("${status}")){
+      echo "${suffix} deployment pending."
+    }
+  } catch (error) {
+    echo "Unable to update Github deployment status: ${error}"
   }
 }
 
@@ -165,10 +169,10 @@ def createFullPRDeployment() {
         cd eagle-helper-pods/openshift/setup-teardown/
 
           # set project to PR deployment template folder
-        find . -name "projectset.config" -exec sed -i -e "s/^\\( *TARGET_PROJECT_SET=*\\)[^ ]*\\(.*\\)*$/\\1PR\\2/" {} \\;
+        find . -name "projectset.config" -exec sed -i -e "s/^\\( *TARGET_PROJECT_SET=*\\)[^ ]*\\(.*\\)*$/\\1${PROJECTSET}\\2/" {} \\;
 
           # set unique name (ie. pr-branchName) for pr builds & deployments
-        cd params/CUSTOM_SETTINGS/PR
+        cd params/CUSTOM_SETTINGS/${PROJECTSET}
         find . -name "*.config" -exec sed -i -e "s/pr-placeholder/${PR_NAME}/g" {} \\;
          # set api vars to pr fork
         cd api
@@ -225,10 +229,10 @@ def cleanUpPR() {
         cd eagle-helper-pods/openshift/setup-teardown/
 
             # set project to PR deployment template folder
-        find . -name "projectset.config" -exec sed -i -e "s/^\\( *TARGET_PROJECT_SET=*\\)[^ ]*\\(.*\\)*$/\\1PR\\2/" {} \\;
+        find . -name "projectset.config" -exec sed -i -e "s/^\\( *TARGET_PROJECT_SET=*\\)[^ ]*\\(.*\\)*$/\\1${PROJECTSET}\\2/" {} \\;
 
             # set to unique name (ie. branchName-appName) for pr builds & deployments
-        cd params/CUSTOM_SETTINGS/PR
+        cd params/CUSTOM_SETTINGS/${PROJECTSET}
         find . -name "*.params" -exec sed -i -e "s/pr-placeholder/${PR_NAME}/g" {} \\;
         find . -name "*.config" -exec sed -i -e "s/pr-placeholder/${PR_NAME}/g" {} \\;
 
@@ -267,8 +271,10 @@ def BUILD_DONE_STATUSES = ['Complete', 'Failed', 'Cancelled']
 def lockName = "eagle-api-${env.JOB_NAME}-${env.BUILD_NUMBER}"
 pipeline {
   environment {
-    TOOLSPROJECT = "esm"
-    DEVPROJECT = "esm-dev"
+    TOOLSPROJECT = "${TOOLS_NAMESPACE ?: '6cdc9e-tools'}"
+    DEVPROJECT = "${DEV_NAMESPACE ?: '6cdc9e-dev'}"
+    PROJECTSET = "${PR_SET ?: 'OCP4_PR'}"
+    OCPHOST = "${OCP_HOST ?: 'apps.silver.devops.gov.bc.ca'}"
     PR_NAME = "${env.CHANGE_BRANCH}".toLowerCase()
     PR_FORK = "${env.CHANGE_FORK}"
   }
@@ -291,7 +297,7 @@ pipeline {
             CLIENT_PUBLIC = sh(returnStdout: true, script: 'cat CLIENT_PUBLIC')
             KC_REALM_ID = sh(returnStdout: true, script: 'cat KC_REALM')
             SSO_HOST = sh(returnStdout: true, script: 'cat KC_HOST')
-            APP_HOST="eagle-${PR_NAME}-dev.pathfinder.gov.bc.ca"
+            APP_HOST="eagle-${PR_NAME}-dev.${OCPHOST}"
           } catch (error) {
             echo "Error retrieving keycloak parameters, message: ${error}"
           }
@@ -345,7 +351,9 @@ pipeline {
           } catch (error) {
             echo "Error retrieving Rocket Chat token"
           }
+          
           createDeploymentStatus('dev', "PENDING")
+          
           echo "Branch to build: ${PR_NAME}"
           echo "Source fork: ${PR_FORK}"
           if (!checkForPRDeployment()) {
@@ -442,14 +450,15 @@ pipeline {
                 def dcObj = openshift.selector('dc', "${PR_NAME}-eagle-api")
                 dcObj.rollout().status()
                 echo ">>>> Deployment Complete"
-
+                
                 createDeploymentStatus('dev', "SUCCESS")
+
                 notifyRocketChat(
-                  "A new version of eagle-api ${PR_NAME} is now in Dev, build: ${env.BUILD_DISPLAY_NAME} \n  https://eagle-${PR_NAME}-dev.pathfinder.gov.bc.ca/ \nChanges: \n ${CHANGELOG}",
+                  "A new version of eagle-api ${PR_NAME} is now in Dev, build: ${env.BUILD_DISPLAY_NAME} \n  https://eagle-${PR_NAME}-dev.${OCPHOST}/ \nChanges: \n ${CHANGELOG}",
                   'deploy'
                 )
                 notifyRocketChat(
-                  "@all A new version of eagle-api is now in Dev and ready for QA. \n  https://eagle-${PR_NAME}-dev.pathfinder.gov.bc.ca/ \nChanges to Dev: \n ${CHANGELOG}",
+                  "@all A new version of eagle-api is now in Dev and ready for QA. \n  https://eagle-${PR_NAME}-dev.${OCPHOST}/ \nChanges to Dev: \n ${CHANGELOG}",
                   'qa'
                 )
               }

--- a/Jenkinsfile-hotfix
+++ b/Jenkinsfile-hotfix
@@ -1,3 +1,5 @@
+#!/usr/bin/env groovy
+
 import groovy.json.JsonOutput
 import groovy.json.JsonSlurper
 import java.util.regex.Pattern
@@ -55,6 +57,9 @@ def CHANGELOG = "No new changes"
 def IMAGE_HASH = "latest"
 
 pipeline {
+  environment {
+    TESTPROJECT = "${TEST_NAMESPACE ?: '6cdc9e-test'}"
+  }
   agent any
   options {
     disableResume()
@@ -114,7 +119,7 @@ pipeline {
             echo "Deploying to hotfix..."
             openshiftTag destStream: 'hotfix-eagle-api', verbose: 'false', destTag: 'hotfix', srcStream: 'hotfix-eagle-api', srcTag: "${IMAGE_HASH}"
             sleep 5
-            openshiftVerifyDeployment depCfg: 'hotfix-eagle-api', namespace: 'esm-test', replicaCount: 1, verbose: 'false', verifyReplicaCount: 'false', waitTime: 600000
+            openshiftVerifyDeployment depCfg: 'hotfix-eagle-api', namespace: TESTPROJECT, replicaCount: 1, verbose: 'false', verifyReplicaCount: 'false', waitTime: 600000
 
             echo ">>>> Deployment Complete"
 

--- a/openshift/templates/eagle-api.bc.json
+++ b/openshift/templates/eagle-api.bc.json
@@ -61,13 +61,7 @@
               "kind": "ImageStreamTag",
               "namespace": "${S2I_NAMESPACE}",
               "name": "nodejs:${NODEJS_VER}"
-            },
-            "env": [
-              {
-                "name": "NODE_ENV",
-                "value": "${NODE_ENV}"
-              }
-            ]
+            }
           }
         },
         "output": {
@@ -139,7 +133,13 @@
               "kind": "ImageStreamTag",
               "namespace": "${S2I_NAMESPACE}",
               "name": "nodejs:${NODEJS_VER}"
-            }
+            },
+            "env": [
+              {
+                "name": "NODE_ENV",
+                "value": "development"
+              }
+            ]
           }
         },
         "output": {

--- a/openshift/templates/eagle-api.dc.json
+++ b/openshift/templates/eagle-api.dc.json
@@ -133,7 +133,7 @@
       },
       "spec": {
         "strategy": {
-          "type": "Rolling"
+          "type": "Recreate"
         },
         "triggers": [
           {
@@ -313,7 +313,7 @@
       },
       "spec": {
         "strategy": {
-          "type": "Rolling"
+          "type": "Recreate"
         },
         "triggers": [
           {


### PR DESCRIPTION
https://bcmines.atlassian.net/browse/FLCN-74

Updated pipeline script to work with both OCP3 and OCP4 Jenkins.  The major changes in the Jenkinsfiles are to use environment variables rather than hardcoding values.

When the Jenkinsfile scripts are run in OCP4 they will use default environment variable values.  In OCP3 they will use values that were set on the Jenkins build pod.

- Fixed data generator pod not being built with development flag.
- Fixed API restart strategy to `Recreate` to release PVC when API pods are restarting