### PR TITLE
NOBUG: fix incorrect value for generator pod mem limit

### DIFF
--- a/openshift/templates/eagle-api.dc.json
+++ b/openshift/templates/eagle-api.dc.json
@@ -478,7 +478,7 @@
                   },
                   "limits": {
                     "cpu": "${NODEJS_CPU_LIMIT}",
-                    "memory": "750m"
+                    "memory": "${NODEJS_MEMORY_LIMIT}"
                   }
                 }
               }


### PR DESCRIPTION
Bad value for generator pod's memory limit was causing silent failures in pipeline.