### PR TITLE
EE-1105 Migrate from node-cron to OpenShift cronjob

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -21,7 +21,6 @@
     ],
     "rules": {
         "block-scoped-var": "error",
-        "indent": ["error", 2],
         "semi": ["error", "always"],
         "brace-style": ["error", "1tbs", { "allowSingleLine": true}],
         "no-trailing-spaces": "error"

--- a/.prettierrc
+++ b/.prettierrc
@@ -1,0 +1,16 @@
+{
+    "printWidth": 120,
+    "tabWidth": 2,
+    "useTabs": false,
+    "semi": true,
+    "singleQuote": true,
+    "trailingComma": "none",
+    "bracketSpacing": true,
+    "jsxBracketSameLine": true,
+    "arrowParens": "avoid",
+    "requirePragma": false,
+    "insertPragma": false,
+    "proseWrap": "never",
+    "htmlWhitespaceSensitivity": "ignore"
+  }
+  

--- a/api/swagger/swagger.yaml
+++ b/api/swagger/swagger.yaml
@@ -688,6 +688,27 @@ definitions:
   ConfigObject:
     type: object
 
+### Task Definitions
+  TaskObject:
+    type: object
+    example: 'A task object'
+    required: [taskType]
+    properties:
+      params:
+        type: object
+        example: '{"taskType": "updateMaterializedView"}'
+      taskType:
+        type: string
+        description: 'The type of task'
+        example: 'updateMaterializedView'
+        enum: &taskTypes
+          - updateMaterializedView
+      materializedViewSubset:
+        type: string
+        description: 'Name of subset to update'
+        example: 'default'
+        enum: &materializedViewSubset
+          - default
 ### Path Definitions
 paths:
   /config:
@@ -7007,7 +7028,47 @@ paths:
           description: "Access Denied"
           schema:
             $ref: "#/definitions/Error"
-
+### Task Routes
+  /task:
+    x-swagger-router-controller: import-task
+    options:
+      tags:
+        - task
+      summary: 'Pre-flight request'
+      operationId: protectedOptions
+      description: 'Options on authenticated task route'
+      responses:
+        '200':
+          description: 'Success'
+        '403':
+          description: 'Access Denied'
+          schema:
+            $ref: '#/definitions/Error'
+    post:
+      tags:
+        - task
+      summary: 'Create a new Task'
+      operationId: protectedCreateTask
+      description: 'Authenticated access to create a Task Worker'
+      security:
+        - Bearer: []
+      x-security-scopes:
+        - sysadmin
+        - project-system-admin
+      parameters:
+        - name: task
+          in: body
+          description: 'Flag to import records'
+          required: true
+          schema:
+            $ref: '#/definitions/TaskObject'
+      responses:
+        '200':
+          description: 'Success'
+        '403':
+          description: 'Access Denied'
+          schema:
+            $ref: '#/definitions/Error'
 ### V2 Routes
 ### Top Level
   /v2/:

--- a/api/tasks/import-task.js
+++ b/api/tasks/import-task.js
@@ -1,0 +1,45 @@
+'use strict';
+
+const defaultLog = require('winston').loggers.get('default');
+const Actions = require('../helpers/actions');
+
+const { updateAllMaterializedViews } = require('../materialized_views/updateViews');
+
+exports.protectedOptions = async function (args, res) {
+  res.status(200).send();
+};
+
+/*Required fields for type of task:
+updateMaterializedView:
+{
+  taskType: updateMaterializedView
+}*/
+exports.protectedCreateTask = async function (args, res) {
+  // validate request parameters
+  if (!args.swagger.params.task || !args.swagger.params.task.value) {
+    defaultLog.error('protectedCreateTask - missing required request body');
+    return Actions.sendResponse(res, 400, 'protectedCreateTask - missing required request body');
+  }
+  if (!args.swagger.params.task.value.taskType) {
+    defaultLog.error('protectedCreateTask - missing required taskType');
+    return Actions.sendResponse(res, 400, 'protectedCreateTask - missing required taskType');
+  }
+
+  switch (args.swagger.params.task.value.taskType) {
+    case 'updateMaterializedView':
+      switch (args.swagger.params.task.value.materializedViewSubset) {
+        case 'default':
+          updateAllMaterializedViews(defaultLog);
+          break;
+        default:
+          defaultLog.error(`protectedCreateTask - unknown materialized view subset`);
+          return Actions.sendResponse(res, 400, `protectedCreateTask - unknown materialized view subset`);
+      }
+      break;
+    default:
+      defaultLog.error('protectedCreateTask - unknown taskType');
+      return Actions.sendResponse(res, 400, 'protectedCreateTask - unknown taskType');
+  }
+  // send response immediately as the tasks will run in the background
+  return Actions.sendResponse(res, 200);
+};

--- a/api/test/tests/tasks/import-task.test.js
+++ b/api/test/tests/tasks/import-task.test.js
@@ -1,0 +1,100 @@
+describe('import-task', () => {
+  describe('protectedCreateTask', () => {
+    let importTask;
+
+    beforeEach(() => {
+      // mock query-actions sendResponse to return whatever is passed to it
+      const mockSendResponse = jest.fn(input => {
+        return Promise.resolve(input);
+      });
+      const queryActions = require('../../../helpers/actions');
+      queryActions.sendResponse = mockSendResponse;
+
+      // require this AFTER its require-mocks have been setup
+      importTask = require('../../../tasks/import-task');
+    });
+
+    it('throws an error if required task param is missing', async () => {
+      const mockArgs = {
+        swagger: {
+          params: {
+            auth_payload: {
+              realm_access: {
+                roles: 'sysadmin'
+              }
+            },
+            task: null
+          }
+        }
+      };
+
+      const res = await importTask.protectedCreateTask(mockArgs, {});
+      expect(res).toEqual({});
+    });
+
+    it('throws an error if required task.value param is missing', async () => {
+      const mockArgs = {
+        swagger: {
+          params: {
+            auth_payload: {
+              realm_access: {
+                roles: 'sysadmin'
+              }
+            },
+            task: {
+              value: null
+            }
+          }
+        }
+      };
+
+      const res = await importTask.protectedCreateTask(mockArgs, {});
+      expect(res).toEqual({});
+    });
+
+    it('throws an error if materializedViewSubset value is invalid', async () => {
+      const mockArgs = {
+        swagger: {
+          params: {
+            auth_payload: {
+              realm_access: {
+                roles: 'sysadmin'
+              }
+            },
+            task: {
+              value: {
+                taskType: 'updateMaterializedView',
+                materializedViewSubset: ''
+              }
+            }
+          }
+        }
+      };
+
+      const res = await importTask.protectedCreateTask(mockArgs, {});
+      expect(res).toEqual({});
+    });
+
+    it('throws an error if required taskType param is missing', async () => {
+      const mockArgs = {
+        swagger: {
+          params: {
+            auth_payload: {
+              realm_access: {
+                roles: 'sysadmin'
+              }
+            },
+            task: {
+              value: {
+                materializedViewSubset: 'default'
+              }
+            }
+          }
+        }
+      };
+
+      const res = await importTask.protectedCreateTask(mockArgs, {});
+      expect(res).toEqual({});
+    });
+  });
+});

--- a/app.js
+++ b/app.js
@@ -61,7 +61,7 @@ swaggerTools.initializeMiddleware(swaggerConfig, function(middleware) {
   );
 
   var routerConfig = {
-    controllers: './api/controllers',
+    controllers: ['./api/controllers', './api/tasks'],
     useStubs: false
   };
 
@@ -80,11 +80,8 @@ swaggerTools.initializeMiddleware(swaggerConfig, function(middleware) {
   }
 
   app_helper.loadMongoose().then(() => {
-    // Start the cron job that updates the materialized views.
-    app_helper.startCron(defaultLog).then(() => {
-      express_server = app.listen(api_default_port, '0.0.0.0', function() {
-        defaultLog.info('Started server on port ' + api_default_port);
-      });
+    express_server = app.listen(api_default_port, '0.0.0.0', function() {
+      defaultLog.info('Started server on port ' + api_default_port);
     });
   }).catch(function (err) {
     defaultLog.info('err:', err);

--- a/app_helper.js
+++ b/app_helper.js
@@ -1,13 +1,7 @@
 const mongoose      = require('mongoose');
-const cron          = require('node-cron');
 const _             = require('lodash');
 const winston       = require('winston');
 const options       = require('./config/mongoose_options').mongooseOptions;
-const { updateAllMaterializedViews } = require('./api/materialized_views/updateViews');
-
-// Set the Cron pattern here.
-// Cron pattern - seconds[0-59] minutes[0-59] hours[0-23] day_of_month[1-31] months[0-11] day_of_week[0-6]
-const MATERIALIZED_VIEWS_CRON_PATTERN = '*/30 * * * *';
 
 // Logging middleware
 winston.loggers.add('default', {
@@ -91,13 +85,7 @@ async function loadMongoose() {
   await loadModels(dbConnection, options, defaultLog);
 }
 
-async function startCron(defaultLog) {
-  // Scheduling material view updates.
-  cron.schedule(MATERIALIZED_VIEWS_CRON_PATTERN, () => updateAllMaterializedViews(defaultLog));
-}
-
 exports.loadMongoose = loadMongoose;
-exports.startCron = startCron;
 exports.loadModels = loadModels;
 exports.dbName = dbName;
 exports.dbConnection = dbConnection;

--- a/openshift/templates/jobs/cron/cron.bc.yaml
+++ b/openshift/templates/jobs/cron/cron.bc.yaml
@@ -1,0 +1,56 @@
+apiVersion: v1
+kind: Template
+metadata:
+  name: eagle-cron
+objects:
+  - apiVersion: image.openshift.io/v1
+    kind: ImageStream
+    metadata:
+      annotations:
+        openshift.io/generated-by: OpenShiftNewBuild
+      creationTimestamp: null
+      labels:
+        build: eagle-cron
+      name: eagle-cron
+    spec:
+      lookupPolicy:
+        local: false
+    status:
+      dockerImageRepository: ''
+  - apiVersion: build.openshift.io/v1
+    kind: BuildConfig
+    metadata:
+      annotations:
+        openshift.io/generated-by: OpenShiftNewBuild
+      creationTimestamp: null
+      labels:
+        build: eagle-cron
+      name: eagle-cron
+    spec:
+      nodeSelector: null
+      output:
+        to:
+          kind: ImageStreamTag
+          name: eagle-cron:latest
+      postCommit: {}
+      resources:
+        requests:
+          cpu: 1
+        limits:
+          cpu: 1
+      source:
+        contextDir: openshift/templates/jobs/cron/docker
+        git:
+          uri: https://github.com/bcgov/eagle-api
+          ref: develop
+        type: Git
+      strategy:
+        dockerStrategy:
+          from:
+            kind: ImageStreamTag
+            name: 'ubi:8.3-227'
+        type: Docker
+      triggers:
+        - type: ConfigChange
+        - imageChange: {}
+          type: ImageChange

--- a/openshift/templates/jobs/cron/cron.configmap.yaml
+++ b/openshift/templates/jobs/cron/cron.configmap.yaml
@@ -1,0 +1,21 @@
+apiVersion: v1
+kind: Template
+metadata:
+  name: eagle-cron
+objects:
+- apiVersion: v1
+  data:
+    updateMaterializedView.sh: |-
+      #!/usr/bin/env bash
+
+      EAGLE_API_URL=https://eagle-dev.pathfinder.gov.bc.ca/api
+
+      echo -e "-------- UPDATING SUBSETS --------\n"
+      echo -e "Updating default subset\n"
+      curl -H "Authorization: Bearer ${TOKEN}" \
+          -H "Content-Type: application/json" \
+          -d '{"taskType":"updateMaterializedView", "materializedViewSubset":"default"}' \
+          ${EAGLE_API_URL}/task
+  kind: ConfigMap
+  metadata:
+    name: cron-config

--- a/openshift/templates/jobs/cron/cron.dc.yaml
+++ b/openshift/templates/jobs/cron/cron.dc.yaml
@@ -1,0 +1,60 @@
+apiVersion: v1
+kind: Template
+metadata:
+  name: ${CRON_NAME}
+objects:
+  - apiVersion: batch/v1beta1
+    kind: CronJob
+    metadata:
+      name: ${CRON_NAME}
+    spec:
+      schedule: ${CRON_SCHEDULE}
+      concurrencyPolicy: 'Forbid'
+      suspend: false
+      jobTemplate:
+        spec:
+          template:
+            metadata:
+              labels:
+                app: ${CRON_NAME}
+            spec:
+              containers:
+                - name: ${CRON_NAME}
+                  image: docker-registry.default.svc:5000/esm/eagle-cron:latest
+                  env:
+                    - name: KEYCLOAK_URL
+                      valueFrom:
+                        secretKeyRef:
+                          key: KEYCLOAK_URL
+                          name: eagle-cron-keycloak
+                    - name: KEYCLOAK_REALM
+                      valueFrom:
+                        secretKeyRef:
+                          key: KEYCLOAK_REALM
+                          name: eagle-cron-keycloak
+                    - name: KEYCLOAK_CLIENT_ID
+                      valueFrom:
+                        secretKeyRef:
+                          key: KEYCLOAK_CLIENT_ID
+                          name: eagle-cron-keycloak
+                    - name: KEYCLOAK_CLIENT_SECRET
+                      valueFrom:
+                        secretKeyRef:
+                          key: KEYCLOAK_CLIENT_SECRET
+                          name: eagle-cron-keycloak
+                  volumeMounts:
+                    - mountPath: /scripts
+                      name: cron-configmap
+              restartPolicy: Never
+              volumes:
+                - configMap:
+                    defaultMode: 420
+                    name: cron-config
+                  name: cron-configmap
+parameters:
+  - name: CRON_SCHEDULE
+    description: 'Cron-like schedule expression. Default: Once every 30 minutes'
+    value: '*/30 * * * *'
+  - name: CRON_NAME
+    decription: 'Name of the cronjob container.'
+    value: 'eagle-cron'

--- a/openshift/templates/jobs/cron/cron.secrets.yaml
+++ b/openshift/templates/jobs/cron/cron.secrets.yaml
@@ -1,0 +1,24 @@
+apiVersion: v1
+kind: Template
+metadata:
+  name: eagle-cron
+objects:
+  - apiVersion: v1
+    data:
+      KEYCLOAK_CLIENT_ID: ${KEYCLOAK_CLIENT_ID}
+      KEYCLOAK_CLIENT_SECRET: ${KEYCLOAK_CLIENT_SECRET}
+      KEYCLOAK_REALM: ${KEYCLOAK_REALM}
+      KEYCLOAK_URL: ${KEYCLOAK_URL}
+    kind: Secret
+    metadata:
+      name: eagle-cron-keycloak
+    type: Opaque
+parameters:
+  - name: 'KEYCLOAK_CLIENT_ID'
+    required: true
+  - name: 'KEYCLOAK_CLIENT_SECRET'
+    required: true
+  - name: 'KEYCLOAK_REALM'
+    required: true
+  - name: 'KEYCLOAK_URL'
+    required: true

--- a/openshift/templates/jobs/cron/docker/Dockerfile
+++ b/openshift/templates/jobs/cron/docker/Dockerfile
@@ -1,0 +1,16 @@
+FROM registry.access.redhat.com/ubi8/ubi:8.3-227
+
+RUN yum install -y jq && \
+    mkdir -p /opt/cron && chgrp -R 0 /opt/cron && \
+    chmod -R g=u /opt/cron && \
+    yum clean all -y
+
+COPY entrypoint.sh /usr/local/bin/entrypoint.sh
+COPY get-token.sh /opt/cron/get-token.sh
+
+RUN chmod +x /usr/local/bin/entrypoint.sh && \
+    chmod +x /opt/cron/get-token.sh
+
+WORKDIR /opt/cron
+
+ENTRYPOINT ["/usr/local/bin/entrypoint.sh"]

--- a/openshift/templates/jobs/cron/docker/entrypoint.sh
+++ b/openshift/templates/jobs/cron/docker/entrypoint.sh
@@ -1,0 +1,16 @@
+#!/usr/bin/env bash
+
+echo -e "-------- STARTING CRON --------\n" 
+
+source /opt/cron/get-token.sh
+
+cp -a /scripts/. /opt/cron/jobs/
+
+for SCRIPT in /opt/cron/jobs/*.sh
+do
+    if [ -f $SCRIPT ]
+    then
+        chmod +x $SCRIPT
+        $SCRIPT
+    fi
+done

--- a/openshift/templates/jobs/cron/docker/get-token.sh
+++ b/openshift/templates/jobs/cron/docker/get-token.sh
@@ -1,0 +1,10 @@
+#!/usr/bin/env bash
+
+echo -e "-------- GETTING ACCESS TOKEN --------\n"
+export TOKEN=$(curl -X POST "${KEYCLOAK_URL}/realms/${KEYCLOAK_REALM}/protocol/openid-connect/token" \
+-H "Content-Type: application/x-www-form-urlencoded" \
+-d "grant_type=client_credentials" \
+-d "client_id=${KEYCLOAK_CLIENT_ID}" \
+-d "client_secret=${KEYCLOAK_CLIENT_SECRET}" | jq -r '.access_token')
+
+

--- a/package.json
+++ b/package.json
@@ -45,7 +45,6 @@
     "mongodb": "~3.3.3",
     "mongoose": "~5.7.7",
     "nconf": "~0.9.1",
-    "node-cron": "~2.0.3",
     "passport": "~0.4.0",
     "passport-local": "~1.0.0",
     "path": "~0.12.7",


### PR DESCRIPTION
https://bcmines.atlassian.net/browse/EE-1105

- Migrated from node-cron to OpenShift cronjob.
- Added new build and deploy configs for the cronjob container.  The this container loads jobs from configmap at runtime instead of embedding jobs in the deploy config.  This makes it easier to modify jobs.
- This container image is also built from the UBI 8 image because the base centos used by NRPTI is no longer available on OCP4 

Note on the `.eslintrc.json` change, the indent rule seems to conflict with Prettier's indenting for nested `switch` statements so I removed it.