### PR TITLE
set minio client endpoint from env

### DIFF
--- a/api/helpers/minio.js
+++ b/api/helpers/minio.js
@@ -5,11 +5,13 @@ var minio = require('minio');
 var path = require('path');
 var _ = require('lodash');
 
+const ep = process.env.MINIO_HOST || 'foo.pathfinder.gov.bc.ca';
+
 /**
  * The Minio client which facilitates the connection to Minio, and through which all calls should be made.
  */
 var minioClient = new minio.Client({
-  endPoint: 'foo.pathfinder.gov.bc.ca',
+  endPoint: ep,
   port: 443,
   useSSL: true,
   accessKey: process.env.MINIO_ACCESS_KEY,

--- a/api/test/repo_warden/model_vs_factory_hash.json
+++ b/api/test/repo_warden/model_vs_factory_hash.json
@@ -54,7 +54,7 @@
     },
     {
       "name": "projectNotification.js",
-      "hash": "6+mdqEIAtK7ogOX5NlBiudhdolc="
+      "hash": "h6Gn15270HdyQtywXyN9f/ytd7I="
     },
     {
       "name": "recentActivity.js",


### PR DESCRIPTION
Doc uploads/downloads were broken due to the **isMockService** check was always returning true, so the minio/s3 calls were being skipped.