### PR TITLE
feat: serve /api/config from mongo

### DIFF
--- a/api/controllers/config.js
+++ b/api/controllers/config.js
@@ -1,0 +1,62 @@
+var defaultLog = require('winston').loggers.get('default');
+var mongoose = require('mongoose');
+var Actions = require('../helpers/actions');
+
+// The keys this endpoint will serve, and the only ones. The schema already drops undeclared
+// fields on write; this is the second half of the same guard, on read — so a key added to the
+// collection out of band still cannot reach the public payload without a code change.
+var PUBLIC_KEYS = [
+  'ENVIRONMENT',
+  'BANNER_COLOUR',
+  'LOG_LEVEL',
+  'API_PATH',
+  'SEARCH_API_PATH',
+  'ADMIN_PATH',
+  'KEYCLOAK_URL',
+  'KEYCLOAK_REALM',
+  'KEYCLOAK_ENABLED',
+  'ANALYTICS_API_URL',
+  'ANALYTICS_DEBUG',
+  'ANALYTICS_ENHANCED_TRACKING',
+  'ANALYTICS_TRAFFIC_TRACKING',
+  'SURVEY_URL',
+  'SHOW_SURVEY_BANNER'
+];
+
+/**
+ * Runtime configuration for the frontends.
+ *
+ * UNAUTHENTICATED — the swagger path carries no `security` block, which is what makes it public
+ * (see api/middleware/swagger-security.js). Everything returned here is world-readable. Never add
+ * a secret, key, or connection string to the Config model.
+ *
+ * Replaces the rproxy ConfigMap that answered this path before. Note that nginx's
+ * `location = /api/config` is an exact match and beats the /api proxy, so this controller is
+ * unreachable through rproxy until that block is removed from eao-nginx.
+ */
+exports.publicGet = async function (args, res) {
+  try {
+    var Config = mongoose.model('Config');
+    // Not `.lean()`: hydrating the document applies the schema defaults to any path the stored
+    // document is missing, so a key added to the model later answers with its declared default
+    // instead of vanishing from the payload until someone backfills it.
+    var doc = await Config.findOne({ _schemaName: 'Config' });
+
+    if (!doc) {
+      defaultLog.error('GET /api/config: no Config document — has the seed migration run?');
+      return Actions.sendResponse(res, 404, { message: 'Configuration not found' });
+    }
+
+    var payload = {};
+    PUBLIC_KEYS.forEach(function (key) {
+      if (doc[key] !== undefined) {
+        payload[key] = doc[key];
+      }
+    });
+
+    return Actions.sendResponse(res, 200, payload);
+  } catch (err) {
+    defaultLog.error('GET /api/config failed:', err);
+    return Actions.sendResponse(res, 500, { message: 'Could not read configuration' });
+  }
+};

--- a/api/helpers/models/config.js
+++ b/api/helpers/models/config.js
@@ -1,0 +1,46 @@
+// Runtime configuration for the frontends, served unauthenticated by GET /api/config.
+//
+// One document. It replaces the nginx ConfigMap that rproxy used to serve from
+// `conf.d/server.conf.tmpl` — same keys, same values, but editable without a Helm deploy.
+//
+// EVERY KEY IS DECLARED HERE ON PURPOSE. Mongoose drops fields that are not in the schema, and
+// that is the guard that stops an operator pasting a secret into this collection and having it
+// served to the public. Adding a key here publishes it; there is no other gate.
+//
+// THE DEFAULTS BELOW ARE SERVED, NOT FALLBACKS. The controller hydrates rather than using .lean(),
+// so a key the stored document lacks answers with its default here — and the frontends merge this
+// payload OVER env.js (server wins). A default is therefore a published value that overwrites
+// whatever the build baked in. Choosing a careless one silently clobbers a bootstrap value.
+//
+// No `read`/`write` arrays, unlike the other models: this endpoint has no ACL and applies no
+// $redact. Carrying permission fields nothing enforces would imply a gate that does not exist.
+//
+// Deliberately absent, and each for its own reason:
+//   API_LOCATION       - the frontend bootstraps from it, so a value served here would fight the
+//                        one baked into env.js at build time.
+//   KEYCLOAK_CLIENT_ID - eagle-admin overrides it from env.js anyway (its config.service.ts
+//                        preserves the local value), and eagle-public has no Keycloak at all.
+//   ENGAGE_API_URL     - zero consumers in either frontend.
+module.exports = require('../models')('Config', {
+  ENVIRONMENT                 : { type: String, default: null },
+  BANNER_COLOUR               : { type: String, default: null },
+  LOG_LEVEL                   : { type: Number, default: 0 },
+
+  API_PATH                    : { type: String, default: '/api' },
+  // Empty means "use eagle-api", and that is the kill switch — eagle-public's getSearchApiPath()
+  // falls back to getApiPath() when this is blank, reverting search with no redeploy.
+  SEARCH_API_PATH             : { type: String, default: '' },
+  ADMIN_PATH                  : { type: String, default: '/admin/' },
+
+  KEYCLOAK_URL                : { type: String, default: null },
+  KEYCLOAK_REALM              : { type: String, default: null },
+  KEYCLOAK_ENABLED            : { type: Boolean, default: true },
+
+  ANALYTICS_API_URL           : { type: String, default: '/analytics' },
+  ANALYTICS_DEBUG             : { type: Boolean, default: false },
+  ANALYTICS_ENHANCED_TRACKING : { type: Boolean, default: true },
+  ANALYTICS_TRAFFIC_TRACKING  : { type: Boolean, default: true },
+
+  SURVEY_URL                  : { type: String, default: null },
+  SHOW_SURVEY_BANNER          : { type: Boolean, default: false }
+}, 'epic');

--- a/api/swagger/swagger.yaml
+++ b/api/swagger/swagger.yaml
@@ -20,6 +20,11 @@ tags:
   externalDocs:
     description: "Find out more about our API"
     url: "http://github.com/bcgov/eagle-api.git"
+- name: "config"
+  description: "Runtime configuration for the frontends"
+  externalDocs:
+    description: "Find out more about our API"
+    url: "http://github.com/bcgov/eagle-api.git"
 - name: "document"
   description: "Operations about documents"
   externalDocs:
@@ -72,6 +77,56 @@ produces:
   - application/json
 
 definitions:
+  ConfigObject:
+    type: object
+    description: "Runtime configuration served to the frontends. Public — never add secrets."
+    properties:
+      ENVIRONMENT:
+        type: string
+        example: "test"
+      BANNER_COLOUR:
+        type: string
+        example: "orange"
+      LOG_LEVEL:
+        type: integer
+        example: 0
+      API_PATH:
+        type: string
+        example: "/api"
+      SEARCH_API_PATH:
+        type: string
+        example: "/eagle-search"
+      ADMIN_PATH:
+        type: string
+        example: "/admin/"
+      KEYCLOAK_URL:
+        type: string
+        example: "https://test.loginproxy.gov.bc.ca/auth"
+      KEYCLOAK_REALM:
+        type: string
+        example: "eao-epic"
+      KEYCLOAK_ENABLED:
+        type: boolean
+        example: true
+      ANALYTICS_API_URL:
+        type: string
+        example: "/analytics"
+      ANALYTICS_DEBUG:
+        type: boolean
+        example: false
+      ANALYTICS_ENHANCED_TRACKING:
+        type: boolean
+        example: true
+      ANALYTICS_TRAFFIC_TRACKING:
+        type: boolean
+        example: true
+      SURVEY_URL:
+        type: string
+        example: null
+      SHOW_SURVEY_BANNER:
+        type: boolean
+        example: false
+
   Authentication:
     type: object
     properties:
@@ -3261,6 +3316,26 @@ paths:
             $ref: "#/definitions/Error"
 
 ### RecentActivity Routes
+  # No `security` block, and that is what makes this public — see
+  # api/middleware/swagger-security.js. Adding one would break every frontend's boot.
+  /config:
+    x-swagger-router-controller: config
+    get:
+      tags:
+        - config
+      summary: "Get runtime configuration"
+      operationId: publicGet
+      description: "Runtime configuration for the frontends. Unauthenticated; contains no secrets."
+      responses:
+        "200":
+          description: "Success"
+          schema:
+            $ref: "#/definitions/ConfigObject"
+        "404":
+          description: "Configuration not found"
+          schema:
+            $ref: "#/definitions/Error"
+
   /public/recentActivity:
     x-swagger-router-controller: recentActivity
     options:

--- a/app_helper.js
+++ b/app_helper.js
@@ -75,6 +75,7 @@ require('./api/helpers/models/topic');
 require('./api/helpers/models/projectNotification');
 require('./api/helpers/models/cacUser');
 require('./api/helpers/models/list');
+require('./api/helpers/models/config');
 
 
 async function loadModels(dbConnection, options, logger) {

--- a/migrations/20260813000000-seed-config.js
+++ b/migrations/20260813000000-seed-config.js
@@ -1,0 +1,92 @@
+'use strict';
+
+// Seeds the single Config document that GET /api/config serves.
+//
+// These values are a transcription of what rproxy's ConfigMap renders today
+// (eao-nginx/helm/rproxy/templates/configmap.yaml, values-{dev,test,prod}.yaml). Cutover is only
+// safe once the served payload matches the ConfigMap key for key — diff them before deleting the
+// `location = /api/config` block from eao-nginx, because that exact-match block wins over the
+// /api proxy and hides any discrepancy until it is removed.
+//
+// Three ConfigMap keys are deliberately NOT seeded: API_LOCATION (the frontend bootstraps from
+// env.js and a served value would fight it), KEYCLOAK_CLIENT_ID (eagle-admin overrides it locally,
+// eagle-public has no Keycloak) and ENGAGE_API_URL (zero consumers in either frontend).
+
+const COMMON = {
+  _schemaName: 'Config',
+  API_PATH: '/api',
+  ADMIN_PATH: '/admin/',
+  KEYCLOAK_REALM: 'eao-epic',
+  KEYCLOAK_ENABLED: true,
+  ANALYTICS_API_URL: '/analytics',
+  ANALYTICS_ENHANCED_TRACKING: true,
+  ANALYTICS_TRAFFIC_TRACKING: true,
+  SURVEY_URL: null,
+  SHOW_SURVEY_BANNER: false
+};
+
+const ENVIRONMENTS = {
+  dev: Object.assign({}, COMMON, {
+    ENVIRONMENT: 'dev',
+    BANNER_COLOUR: 'red',
+    LOG_LEVEL: 0,
+    // Only dev has a search service; test and prod render this empty, which is the documented
+    // kill switch back to eagle-api.
+    SEARCH_API_PATH: '/eagle-search',
+    KEYCLOAK_URL: 'https://dev.loginproxy.gov.bc.ca/auth',
+    ANALYTICS_DEBUG: true
+  }),
+  test: Object.assign({}, COMMON, {
+    ENVIRONMENT: 'test',
+    BANNER_COLOUR: 'orange',
+    LOG_LEVEL: 0,
+    SEARCH_API_PATH: '',
+    KEYCLOAK_URL: 'https://test.loginproxy.gov.bc.ca/auth',
+    ANALYTICS_DEBUG: true
+  }),
+  prod: Object.assign({}, COMMON, {
+    ENVIRONMENT: 'prod',
+    BANNER_COLOUR: '',
+    LOG_LEVEL: 4,
+    SEARCH_API_PATH: '',
+    KEYCLOAK_URL: 'https://loginproxy.gov.bc.ca/auth',
+    ANALYTICS_DEBUG: false
+  })
+};
+
+// API_HOSTNAME reaches the pod through the eagle-api ConfigMap (helm/eagle-api/values-*.yaml,
+// mounted by `envFrom` in templates/deployment.yaml). An unrecognised value throws rather than
+// falling back: the seed runs once and the `existing` guard stops a later run from repairing it,
+// so a wrong guess in prod is a wrong document forever, and a silent one.
+function resolveEnvironment() {
+  const host = process.env.API_HOSTNAME || '';
+  if (host.startsWith('projects.eao.gov.bc.ca')) return 'prod';
+  if (host.startsWith('eagle-test.')) return 'test';
+  if (host.startsWith('eagle-dev.')) return 'dev';
+  throw new Error(
+    `Cannot seed Config: API_HOSTNAME is '${host || 'unset'}'. Set it to the environment being ` +
+    'migrated (locally: API_HOSTNAME=eagle-dev.apps.silver.devops.gov.bc.ca).'
+  );
+}
+
+module.exports = {
+  async up(db) {
+    const epicCollection = db.collection('epic');
+    const name = resolveEnvironment();
+    const doc = ENVIRONMENTS[name];
+
+    const existing = await epicCollection.findOne({ _schemaName: 'Config' });
+    if (existing) {
+      console.log(`Config document already exists (${existing.ENVIRONMENT}); leaving it alone.`);
+      return;
+    }
+
+    await epicCollection.insertOne(doc);
+    console.log(`Inserted Config document for '${name}' (API_HOSTNAME=${process.env.API_HOSTNAME || 'unset'})`);
+  },
+
+  async down(db) {
+    const epicCollection = db.collection('epic');
+    await epicCollection.deleteMany({ _schemaName: 'Config' });
+  }
+};

--- a/test/controllers/config.test.js
+++ b/test/controllers/config.test.js
@@ -1,0 +1,120 @@
+/**
+ * Unit Tests for Config Controller
+ *
+ * GET /api/config is unauthenticated and world-readable, so the tests that matter are the ones
+ * about what it refuses to serve, and about falsy values surviving — SEARCH_API_PATH: '' is the
+ * documented kill switch back to eagle-api, and a truthy filter would silently drop it.
+ */
+
+const { expect } = require('chai');
+const sinon = require('sinon');
+const mongoose = require('mongoose');
+
+const configController = require('../../api/controllers/config');
+
+// Minimal stand-in for the Express response the controller is handed.
+function fakeRes() {
+  return {
+    statusCode: null,
+    body: null,
+    status(code) { this.statusCode = code; return this; },
+    json(payload) { this.body = payload; return this; }
+  };
+}
+
+// mongoose.model('Config') -> findOne(...) -> resolves `doc`
+function stubConfigModel(doc, err) {
+  return sinon.stub(mongoose, 'model').withArgs('Config').returns({
+    findOne: () => (err ? Promise.reject(err) : Promise.resolve(doc))
+  });
+}
+
+describe('Config Controller', () => {
+  afterEach(() => sinon.restore());
+
+  it('serves the stored configuration', async () => {
+    stubConfigModel({ _schemaName: 'Config', ENVIRONMENT: 'test', BANNER_COLOUR: 'orange' });
+    const res = fakeRes();
+
+    await configController.publicGet({}, res);
+
+    expect(res.statusCode).to.equal(200);
+    expect(res.body.ENVIRONMENT).to.equal('test');
+    expect(res.body.BANNER_COLOUR).to.equal('orange');
+  });
+
+  it('preserves falsy values instead of dropping them', async () => {
+    stubConfigModel({
+      _schemaName: 'Config',
+      SEARCH_API_PATH: '',        // the kill switch — must survive
+      SHOW_SURVEY_BANNER: false,
+      LOG_LEVEL: 0,
+      SURVEY_URL: null
+    });
+    const res = fakeRes();
+
+    await configController.publicGet({}, res);
+
+    expect(res.body).to.have.property('SEARCH_API_PATH', '');
+    expect(res.body).to.have.property('SHOW_SURVEY_BANNER', false);
+    expect(res.body).to.have.property('LOG_LEVEL', 0);
+    expect(res.body).to.have.property('SURVEY_URL', null);
+  });
+
+  it('serves no key outside the public allowlist', async () => {
+    stubConfigModel({
+      _schemaName: 'Config',
+      _id: 'abc123',
+      ENVIRONMENT: 'test',
+      MONGODB_PASSWORD: 'hunter2',   // an operator pasting a secret into the collection
+      API_LOCATION: 'https://example.com',
+      KEYCLOAK_CLIENT_ID: 'eagle-api-console'
+    });
+    const res = fakeRes();
+
+    await configController.publicGet({}, res);
+
+    expect(res.body).to.not.have.property('MONGODB_PASSWORD');
+    expect(res.body).to.not.have.property('_id');
+    expect(res.body).to.not.have.property('_schemaName');
+    // Both are ConfigMap keys we deliberately stopped serving.
+    expect(res.body).to.not.have.property('API_LOCATION');
+    expect(res.body).to.not.have.property('KEYCLOAK_CLIENT_ID');
+  });
+
+  it('fills a key the stored document is missing from the schema default', async () => {
+    // The reason this controller does not use .lean(): a key added to the model later must answer
+    // with its declared default rather than disappear from the payload until someone backfills it.
+    require('../../api/helpers/models/config');
+    const Config = mongoose.model('Config');
+    const partial = Config.hydrate({ _schemaName: 'Config', ENVIRONMENT: 'test' });
+    sinon.stub(mongoose, 'model').withArgs('Config').returns({
+      findOne: () => Promise.resolve(partial)
+    });
+    const res = fakeRes();
+
+    await configController.publicGet({}, res);
+
+    expect(res.body).to.have.property('ADMIN_PATH', '/admin/');
+    expect(res.body).to.have.property('KEYCLOAK_ENABLED', true);
+  });
+
+  it('404s when the document is missing rather than serving an empty config', async () => {
+    stubConfigModel(null);
+    const res = fakeRes();
+
+    await configController.publicGet({}, res);
+
+    expect(res.statusCode).to.equal(404);
+  });
+
+  it('500s when the read fails', async () => {
+    stubConfigModel(null, new Error('connection lost'));
+    const res = fakeRes();
+
+    await configController.publicGet({}, res);
+
+    expect(res.statusCode).to.equal(500);
+    expect(res.body).to.not.have.property('stack');
+  });
+});


### PR DESCRIPTION
## What

Adds `GET /api/config`, backed by a single document in the `epic` collection, to replace the static file rproxy renders into its ConfigMap.

Today changing a banner colour or a search path means editing `eao-nginx/helm/rproxy/values-*.yaml` and running a Helm deploy. After this it is a document edit.

## Nothing changes on deploy

Deploying this to test or prod is a no-op. Two independent reasons:

- **The route is unreachable.** `eao-nginx/conf.d/server.conf.tmpl:107-115` is `location = /api/config` — an exact match, which beats the `location /api` proxy. Every frontend keeps getting the ConfigMap byte for byte until that block is deleted.
- **The migration does not run.** `helm/eagle-api/values.yaml:132-134` has `migrations.enabled: false`; it is a `pre-upgrade` hook you opt into with `--set migrations.enabled=true`.

Cutover is a separate change to `eao-nginx`, gated on diffing the seeded document against the rendered ConfigMap per environment.

## Design notes for review

**The key set is declared twice, on purpose.** This endpoint is unauthenticated. The schema drops undeclared fields on write; the controller's `PUBLIC_KEYS` allowlist drops them on read. Adding a key to the collection does not publish it.

**Three ConfigMap keys are deliberately not served.** `API_LOCATION` (the frontend bootstraps from it, so a served value would fight the one baked into `env.js`), `KEYCLOAK_CLIENT_ID` (eagle-admin overrides it locally, eagle-public has no Keycloak), `ENGAGE_API_URL` (no consumer in either frontend).

**The model has no `read`/`write` arrays, and that is load-bearing.** Registering the model widens `/api/search`'s schema allowlist, since `api/controllers/search.js:334` builds it from `mongoose.modelNames()` — so `_schemaName=Config` now passes validation instead of returning 400. It still returns nothing: `api/aggregators/itemAggregator.js:25-44` redacts on `read`, and a document with no `read` field hits `$$PRUNE` for every role, sysadmin included. Adding an ACL array later would expose the raw document through search, including keys the controller withholds.

**The controller hydrates rather than using `.lean()`**, so a key added to the model later answers with its declared default instead of vanishing from the payload until someone backfills it. The consequence is that schema defaults are *served*, and the frontends merge this payload over `env.js` with the server winning — so a default overwrites a bootstrap value rather than acting as a fallback. Called out in the model.

**The migration throws on an unrecognised `API_HOSTNAME`** rather than defaulting to dev. It seeds once and the `existing` guard stops a later run from repairing it, so a wrong guess in prod would be a wrong document forever, and a silent one. `API_HOSTNAME` reaches the migration pod via `envFrom` in `templates/migration-job.yaml:29-31` and is set in all three values files.

## Not affected

`eagle-typesense` ignores the new document — `src/index.js:166` filters the change stream on an `_schemaName` allowlist that does not include `Config`, and full sync is per-schema. The migration inserts through the raw driver, so the mongoose `post('save')` audit hook does not fire.

## Tests

`test/controllers/config.test.js`, 6 cases. The ones that earn their keep:

- falsy values survive — `SEARCH_API_PATH: ''` is the documented kill switch back to eagle-api, and a truthy filter would silently disable search
- no key outside the allowlist is served, including a secret pasted into the document
- a key missing from the stored document fills from its schema default (fails if `.lean()` is reintroduced)

Full suite: 636 passing.
