### PR TITLE
fix: stop caching a failed /api/config

### DIFF
--- a/api/controllers/config.js
+++ b/api/controllers/config.js
@@ -44,6 +44,10 @@ exports.publicGet = async function (args, res) {
 
     if (!doc) {
       defaultLog.error('GET /api/config: no Config document — has the seed migration run?');
+      // app.js stamps max-age=60 on every unauthenticated GET before routing. A good config
+      // should be cacheable; a failure must not be, or a brief outage sticks in rproxy and in
+      // every browser for a minute after the database comes back.
+      res.setHeader('Cache-Control', 'no-store');
       return Actions.sendResponse(res, 404, { message: 'Configuration not found' });
     }
 
@@ -57,6 +61,7 @@ exports.publicGet = async function (args, res) {
     return Actions.sendResponse(res, 200, payload);
   } catch (err) {
     defaultLog.error('GET /api/config failed:', err);
+    res.setHeader('Cache-Control', 'no-store');
     return Actions.sendResponse(res, 500, { message: 'Could not read configuration' });
   }
 };

--- a/test/controllers/config.test.js
+++ b/test/controllers/config.test.js
@@ -17,6 +17,8 @@ function fakeRes() {
   return {
     statusCode: null,
     body: null,
+    headers: {},
+    setHeader(name, value) { this.headers[name] = value; },
     status(code) { this.statusCode = code; return this; },
     json(payload) { this.body = payload; return this; }
   };
@@ -108,6 +110,17 @@ describe('Config Controller', () => {
     expect(res.statusCode).to.equal(404);
   });
 
+  it('does not let the 404 be cached', async () => {
+    // app.js has already stamped max-age=60 on this unauthenticated GET by the time the
+    // controller runs — a missing config must not stick in rproxy for a minute.
+    stubConfigModel(null);
+    const res = fakeRes();
+
+    await configController.publicGet({}, res);
+
+    expect(res.headers['Cache-Control']).to.equal('no-store');
+  });
+
   it('500s when the read fails', async () => {
     stubConfigModel(null, new Error('connection lost'));
     const res = fakeRes();
@@ -116,5 +129,14 @@ describe('Config Controller', () => {
 
     expect(res.statusCode).to.equal(500);
     expect(res.body).to.not.have.property('stack');
+  });
+
+  it('does not let the 500 be cached', async () => {
+    stubConfigModel(null, new Error('connection lost'));
+    const res = fakeRes();
+
+    await configController.publicGet({}, res);
+
+    expect(res.headers['Cache-Control']).to.equal('no-store');
   });
 });


### PR DESCRIPTION
## What

`app.js:75-80` stamps `Cache-Control: max-age=60` on every unauthenticated GET **before routing**, so it lands on `/api/config`'s 404 and 500 as well as its 200. The controller set no header of its own. Both error paths now set `no-store`; the 200 stays cacheable.

## Why this matters, and why now

Today this is theoretical: `eao-nginx`'s `location = /api/config` is an exact match and beats the `/api` proxy, so this controller is unreachable and nothing here changes behaviour on deploy.

It stops being theoretical at cutover. Once eagle-api answers the path, a three-second Mongo blip returns one 500 — and that 500 is then cached at rproxy and in every browser for a full minute after the database has recovered. The cache converts a transient into a minute-long outage for anyone who loads a page during it.

This is a precondition for the frontend work that reacts to a failed config fetch ([bcgov/eagle-admin#921](https://github.com/bcgov/eagle-admin/pull/921)), which is why it lands ahead of the cutover rather than with it.

## Mechanism

`Actions.sendResponse` (`api/helpers/actions.js:59-61`) is `res.status().json()` and overrides no headers, so a `res.setHeader` immediately before it wins over the app-level default.

## Not in this PR

The same pre-routing stamp still marks every **other** public 404 and 500 cacheable for a minute. The real fix is to downgrade any status ≥ 400 to `no-store` — an `on-headers` hook or a `res.writeHead` wrapper — which changes behaviour on every public route and wants its own ticket and its own soak. Raised in review; deliberately not folded in here.

Also still to come, in the `eao-nginx` cutover commit rather than this one: `proxy_cache_valid 200 60s` and `proxy_cache_use_stale error timeout updating http_500 http_502 http_503 http_504` on the `/api` block. The repo currently has `proxy_cache globalcache` with neither directive anywhere, so a *good* config does not keep serving through an eagle-api blip.

## Tests

Two cases added to `test/controllers/config.test.js` asserting `Cache-Control: no-store` on the 404 and the 500. The existing `fakeRes()` had no `setHeader`, so it gained one — without it the pre-existing 404 and 500 tests would have thrown.

Full suite: **638 passing**.
