### PR TITLE
fix: seed dev config with no search path

### DIFF
--- a/README.md
+++ b/README.md
@@ -126,25 +126,14 @@ replaces any existing data. The volume (`eagle-api_mongodb-data`) persists acros
 `yarn db:down` / `yarn db:up` restarts.
 
 
-### Database Conversions
+### Database Migrations
 
-In the process of developing this application, we have database conversion scripts that must be run in order to update the db model so that the newest codebase can work properly.  There are currently two methods of doing the database conversion depending on how long-lived and memory intensive the conversion is.
+Migrations live in `migrations/` and are run by `run_migration.js` (`yarn migrate`), which holds the
+migrate-mongo config inline. The bare `migrate-mongo` CLI does not work — there is no
+`migrate-mongo-config.js`.
 
-### Method 1: db-migrate
-
-### Method 2: node scripts named migration* in the root folder
-
-### Method 1
-
-See <https://www.npmjs.com/package/db-migrate> for documentation on running the db migrate command.  General use case for local development at the root folder:
-
-```./node_modules/db-migrate/bin/db-migrate up```
-
-For dev/test/prod environments, you will need to change the database.json file in the root folder accordingly and run with the --env param.  See <https://www.npmjs.com/package/db-migrate> for more information.
-
-### Method 2
-
-In the root folder, there are files named migrateDocuments*.js.  These are large, long-running, memory intensive scripts that operated on the vast majority of the EPIC documents.  As a result, db-migrate was slow and unreliable given the nature of the connection to our database.  As a result, these nodejs scripts operate using the mongodb driver in nodejs and can handle a more complicated, robust approach to doing the database conversion.  They can be run from your local machine as long as there is a ```oc port-forward``` tunnel from your machine to the openshift mongdb database.  Change the user/pass/port/host/authenticationDatabase params and the script will execute against the mongodb pod directly.
+See [migrations/README.md](migrations/README.md) for how to run them locally against a port-forward,
+how to run them in-cluster with `oc exec`, and why that is preferred over the Helm `pre-upgrade` hook.
 
 ## Developing
 

--- a/migrations/20260813000000-seed-config.js
+++ b/migrations/20260813000000-seed-config.js
@@ -30,9 +30,11 @@ const ENVIRONMENTS = {
     ENVIRONMENT: 'dev',
     BANNER_COLOUR: 'red',
     LOG_LEVEL: 0,
-    // Only dev has a search service; test and prod render this empty, which is the documented
-    // kill switch back to eagle-api.
-    SEARCH_API_PATH: '/eagle-search',
+    // Empty, and dev is the environment that has no search service: eao-nginx removed the dev
+    // search route outright ("The Azure dev search service is gone (2026-08-11 teardown)",
+    // values-dev.yaml), and the live rproxy-config ConfigMap renders "" to match. Seeding
+    // /eagle-search would point dev search at an upstream that no longer exists.
+    SEARCH_API_PATH: '',
     KEYCLOAK_URL: 'https://dev.loginproxy.gov.bc.ca/auth',
     ANALYTICS_DEBUG: true
   }),
@@ -40,6 +42,10 @@ const ENVIRONMENTS = {
     ENVIRONMENT: 'test',
     BANNER_COLOUR: 'orange',
     LOG_LEVEL: 0,
+    // Test is the environment that does have one, but this value is knowingly stale against the
+    // chart: values-test.yaml sets searchApiPath "/eagle-search" while live test's ConfigMap has
+    // no such key, and the seed must match live at the time it runs. It flips to '/eagle-search'
+    // when test's rproxy is next helm-upgraded.
     SEARCH_API_PATH: '',
     KEYCLOAK_URL: 'https://test.loginproxy.gov.bc.ca/auth',
     ANALYTICS_DEBUG: true

--- a/migrations/README.md
+++ b/migrations/README.md
@@ -1,42 +1,65 @@
-## How to migrate local database
+## How to run migrations
 
-### Create migration boilerplate
+Migrations are run by `run_migration.js` (`yarn migrate`), which holds the migrate-mongo config
+inline and seeds the `changelog` collection from the legacy db-migrate `migrations` collection on
+first run. There is no `migrate-mongo-config.js`, so the bare `migrate-mongo` CLI does not work.
 
-`./node_modules/db-migrate/bin/db-migrate create myMigrationName`
+### Locally, against a port-forward
 
-This will create a date stamped **boilerplate* migration file for you in the `./migrations` directory, such as  *20190625114200-myMigrationName.js* .
-Modify this file to implement your migration.
+```bash
+oc port-forward -n 6cdc9e-dev svc/eagle-api-mongodb 27017:27017
 
-### Run a migration
+# Credentials are required — the cluster's MongoDB runs with --auth
+export MONGODB_USERNAME=$(oc --context epic-dev get secret eagle-api-mongodb -n 6cdc9e-dev \
+  -o jsonpath='{.data.MONGODB_USER}' | base64 -d)
+export MONGODB_PASSWORD=$(oc --context epic-dev get secret eagle-api-mongodb -n 6cdc9e-dev \
+  -o jsonpath='{.data.MONGODB_PASSWORD}' | base64 -d)
 
-` ./node_modules/db-migrate/bin/db-migrate up`
+API_HOSTNAME=eagle-dev.apps.silver.devops.gov.bc.ca node run_migration.js
+```
 
+`API_HOSTNAME` is required by any migration that has to know which environment it is seeding. The
+host defaults to `mongodb://localhost:27017/epic`, which is what the port-forward gives you, but the
+credentials do not default to anything usable: the cluster runs mongod with `--auth --keyFile`
+(`helm/eagle-api/templates/mongodb-deployment.yaml:33-40`), so without the two exports above the
+first query fails. Other overrides: `MONGODB_SERVICE_HOST`, `MONGODB_PORT`, `MONGODB_DATABASE`,
+`MONGODB_AUTHSOURCE`.
 
-### Load dump into db and run migrations (optional)
+Against a local docker-compose Mongo instead — which runs with no auth — the bare command works:
+`yarn db:up`, then `yarn migrate`.
 
+### In-cluster
 
-1. Move your newly generated migration file out of the migrations folder(ie. *20190625114200-myMigrationName.js*). This is to ensure a
-clean state to test your new migration against.
+```bash
+oc --context epic-dev exec -n 6cdc9e-dev deploy/eagle-api -- node run_migration.js
+```
 
-2. Run the following command to load a dump file and apply all existing migrations:
+Preferred over the Helm pre-upgrade hook. The app pod already has `API_HOSTNAME` and the MongoDB
+host/database via `envFrom` on the `eagle-api` ConfigMap, plus the credentials from the
+`eagle-api-mongodb` secret, and it runs the image that is actually deployed. The hook (`helm/eagle-api/templates/migration-job.yaml`, enabled by
+`migrations.enabled=true`) has two traps:
 
-    1. `cd dumps_folder && mongorestore -d epic some_unzipped_dump/`
-    2. `cd eagle_api_root/ && ./node_modules/db-migrate/bin/db-migrate up`
-    2. `node migrateDocuments.js`
+- the command documented at `helm/eagle-api/values.yaml:132` omits `--values values-{env}.yaml`, so
+  the ConfigMap re-renders without `API_HOSTNAME` and the migration throws;
+- `migrations.image.tag` is pinned to `"v2.10.42"`, so the `| default .Values.image.tag` fallback
+  never fires and the job silently runs an image older than the migration you just wrote.
 
-3. Put your new migration file back into the **/migrations** folder and run:
+### Writing a migration
 
-    * `./node_modules/db-migrate/bin/db-migrate up`
+Add a `YYYYMMDDHHMMSS-name.js` file to this directory exporting `up(db, client)` and
+`down(db, client)`. Nothing generates the boilerplate; copy the newest file.
 
-### Re-run migration (local testing)
+Test it against a dump before it goes anywhere real:
 
-** This won't unclobber data, just allow a rerun of a migration. You may
-need to dump and restore if the last migration attempt mangled data. **
+```bash
+cd dumps_folder && mongorestore -d epic some_unzipped_dump/
+cd eagle_api_root && node run_migration.js
+```
 
-1. View all migrations applied, in mongo shell
+To re-run one locally, delete its `changelog` entry in the mongo shell and run again. This does not
+unclobber data — restore the dump if the last attempt mangled it.
 
-    * `db.migrations.find()`
-
-2. The most recent migration will be at the bottom of the list
-
-    * `db.migrations.deleteOne({ _id: ObjectId(my_most_recent_migrationd_id)})`
+```js
+db.changelog.find()
+db.changelog.deleteOne({ fileName: '20190625114200-myMigrationName.js' })
+```

--- a/package.json
+++ b/package.json
@@ -38,7 +38,7 @@
     "test:watch": "mocha 'test/aggregators/**/*.test.js' 'test/controllers/**/*.test.js' 'test/helpers/**/*.test.js' 'test/models/**/*.test.js' --recursive --watch",
     "test:smoke": "mocha 'test/smoke/**/*.test.js' --recursive --exit --timeout 30000",
     "test:smoke:public": "mocha 'test/smoke/public-*.test.js' --recursive --exit --timeout 30000",
-    "migrate": "migrate-mongo up"
+    "migrate": "node run_migration.js"
   },
   "dependencies": {
     "agenda": "5.0.0",


### PR DESCRIPTION
## What

The Config seed migration hardcoded `SEARCH_API_PATH: '/eagle-search'` for dev. It becomes `''`. Plus three fixes to the runbook that step of the cutover depends on.

Step 1 of the `/api/config` cutover. Nothing here changes behaviour on deploy — the migration is opt-in (`migrations.enabled: false`) and the endpoint is still shadowed by nginx until [bcgov/eao-nginx#31](https://github.com/bcgov/eao-nginx/pull/31) lands.

## Why the dev value was wrong

The dev block was transcribed from `eao-nginx/helm/rproxy/values-dev.yaml`. That file has since changed: master **removed** `searchApiPath` and the search upstream from dev entirely —

> `# searchApiPath deliberately absent: empty means eagle-api serves Project/Document/DocumentChunk search. The Azure dev search service is gone (2026-08-11 teardown).`

— and the live `rproxy-config` ConfigMap renders `""` to match. Seeding `/eagle-search` would have pointed dev search at an upstream that no longer exists, on the one step of the cutover whose entire job is to preserve behaviour exactly.

I only caught it because the local checkout was two commits behind with a clean `git status`; the tracking ref had last been moved by a push rather than a fetch.

**Test keeps `''` knowingly.** `values-test.yaml` sets `/eagle-search`, but test's ConfigMap has not been re-rendered yet and still has no such key. The seed must match live at the time it runs, so it stays empty and flips when test's rproxy is next upgraded. The comment says so, because the next reader will otherwise "fix" it.

## The runbook did not work

Three separate ways, all on the path of the very next step (`node run_migration.js` against dev):

- **`yarn migrate` was broken.** It invoked bare `migrate-mongo up`, which looks for a `migrate-mongo-config.js`. That config was inlined into `run_migration.js` in `9c85a3c`, so the script could not have worked since. Now `node run_migration.js`.
- **`migrations/README.md` documented `db-migrate`** — not in the dependency tree, binary not installed, and it named `migrateDocuments*.js` and `database.json`, neither of which exists. Rewritten around the two commands that do work, with the reason `oc exec` beats the Helm `pre-upgrade` hook: the app pod already carries `API_HOSTNAME` and the Mongo settings, whereas the hook route drops `API_HOSTNAME` if you follow the documented command literally, and runs a pinned image older than the migration if you forget the tag override.
- **The local recipe omitted credentials.** The cluster's mongod runs `--auth --keyFile` (`helm/eagle-api/templates/mongodb-deployment.yaml:33-40`) and `run_migration.js` defaults both credentials to `''`, so a bare port-forward run dies on the first query. Now exports them from the `eagle-api-mongodb` secret. `README.md` at the repo root carried the same dead `db-migrate` instructions and is now a pointer, so there is one runbook rather than two that disagree.

## Tests

No new cases: this changes a seeded literal and three documents. `test/controllers/config.test.js` already pins the payload shape and the deliberate exclusions.

Full suite: **638 passing**.
