### PR TITLE
fix(docker): drop the dead COPY .yarn line

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -22,7 +22,6 @@ WORKDIR /opt/app-root/src
 
 # Copy package files and yarn configuration
 COPY package.json yarn.lock .yarnrc.yml ./
-COPY .yarn ./.yarn
 
 # Install production dependencies only (devDependencies are not needed at runtime)
 RUN corepack enable && yarn workspaces focus --production


### PR DESCRIPTION
Follow-up to the dependabot consolidation. Untracking `.yarn/install-state.gz` left **no** tracked files under `.yarn`, so `COPY .yarn ./.yarn` now fails the image build:

```
ERROR: failed to compute cache key: failed to calculate checksum of ref ...: "/.yarn": not found
```

Nothing needed that copy: `.yarnrc.yml` is just `nodeLinker: node-modules` with no `yarnPath`, and yarn comes from corepack via `packageManager`.

Verified locally with `docker build` — image builds clean.